### PR TITLE
feat: Add SetLimitDetailedBodyBytes method to restrict log writing.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   status:
     patch: true
-    project: false # disabled because project coverage is not stable
+    project: true
 comment:
   layout: "flags, files"
   behavior: once

--- a/core/collection/set.go
+++ b/core/collection/set.go
@@ -15,13 +15,99 @@ const (
 	stringType
 )
 
+// TypedSet is a type-safe generic set collection. It's not thread-safe,
+// use with synchronization for concurrent access.
+//
+// Advantages over the legacy Set:
+// - Compile-time type safety (no runtime type validation needed)
+// - Better performance (no type assertions or reflection overhead)
+// - Cleaner API (single Add method instead of multiple type-specific methods)
+// - No need for type-specific Keys methods (KeysInt, KeysStr, etc.)
+// - Zero-allocation for empty checks and direct type access
+type TypedSet[T comparable] struct {
+	data map[T]lang.PlaceholderType
+}
+
+// NewTypedSet returns a new type-safe set.
+func NewTypedSet[T comparable]() *TypedSet[T] {
+	return &TypedSet[T]{
+		data: make(map[T]lang.PlaceholderType),
+	}
+}
+
+// NewIntSet returns a new int-typed set.
+func NewIntSet() *TypedSet[int] {
+	return NewTypedSet[int]()
+}
+
+// NewInt64Set returns a new int64-typed set.
+func NewInt64Set() *TypedSet[int64] {
+	return NewTypedSet[int64]()
+}
+
+// NewUintSet returns a new uint-typed set.
+func NewUintSet() *TypedSet[uint] {
+	return NewTypedSet[uint]()
+}
+
+// NewUint64Set returns a new uint64-typed set.
+func NewUint64Set() *TypedSet[uint64] {
+	return NewTypedSet[uint64]()
+}
+
+// NewStringSet returns a new string-typed set.
+func NewStringSet() *TypedSet[string] {
+	return NewTypedSet[string]()
+}
+
+// Add adds items to the set. Duplicates are automatically ignored.
+func (s *TypedSet[T]) Add(items ...T) {
+	for _, item := range items {
+		s.data[item] = lang.Placeholder
+	}
+}
+
+// Contains checks if an item exists in the set.
+func (s *TypedSet[T]) Contains(item T) bool {
+	_, ok := s.data[item]
+	return ok
+}
+
+// Remove removes an item from the set.
+func (s *TypedSet[T]) Remove(item T) {
+	delete(s.data, item)
+}
+
+// Keys returns all elements in the set as a slice.
+func (s *TypedSet[T]) Keys() []T {
+	keys := make([]T, 0, len(s.data))
+	for key := range s.data {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// Count returns the number of items in the set.
+func (s *TypedSet[T]) Count() int {
+	return len(s.data)
+}
+
+// Clear removes all items from the set.
+func (s *TypedSet[T]) Clear() {
+	s.data = make(map[T]lang.PlaceholderType)
+}
+
 // Set is not thread-safe, for concurrent use, make sure to use it with synchronization.
+// Deprecated: Use TypedSet[T] instead for better type safety and performance.
+// TypedSet provides compile-time type checking and eliminates the need for type-specific methods.
 type Set struct {
 	data map[any]lang.PlaceholderType
 	tp   int
 }
 
 // NewSet returns a managed Set, can only put the values with the same type.
+// Deprecated: Use NewTypedSet[T]() instead for better type safety and performance.
+// Example: NewIntSet() instead of NewSet() with AddInt()
 func NewSet() *Set {
 	return &Set{
 		data: make(map[any]lang.PlaceholderType),
@@ -30,6 +116,8 @@ func NewSet() *Set {
 }
 
 // NewUnmanagedSet returns an unmanaged Set, which can put values with different types.
+// Deprecated: Use TypedSet[any] or multiple TypedSet instances for different types instead.
+// If you really need mixed types, consider using map[any]struct{} directly.
 func NewUnmanagedSet() *Set {
 	return &Set{
 		data: make(map[any]lang.PlaceholderType),
@@ -38,6 +126,7 @@ func NewUnmanagedSet() *Set {
 }
 
 // Add adds i into s.
+// Deprecated: Use TypedSet[T].Add() instead for better type safety and performance.
 func (s *Set) Add(i ...any) {
 	for _, each := range i {
 		s.add(each)
@@ -45,6 +134,8 @@ func (s *Set) Add(i ...any) {
 }
 
 // AddInt adds int values ii into s.
+// Deprecated: Use NewIntSet().Add() instead for better type safety and performance.
+// Example: intSet := NewIntSet(); intSet.Add(1, 2, 3)
 func (s *Set) AddInt(ii ...int) {
 	for _, each := range ii {
 		s.add(each)
@@ -52,6 +143,8 @@ func (s *Set) AddInt(ii ...int) {
 }
 
 // AddInt64 adds int64 values ii into s.
+// Deprecated: Use NewInt64Set().Add() instead for better type safety and performance.
+// Example: int64Set := NewInt64Set(); int64Set.Add(1, 2, 3)
 func (s *Set) AddInt64(ii ...int64) {
 	for _, each := range ii {
 		s.add(each)
@@ -59,6 +152,8 @@ func (s *Set) AddInt64(ii ...int64) {
 }
 
 // AddUint adds uint values ii into s.
+// Deprecated: Use NewUintSet().Add() instead for better type safety and performance.
+// Example: uintSet := NewUintSet(); uintSet.Add(1, 2, 3)
 func (s *Set) AddUint(ii ...uint) {
 	for _, each := range ii {
 		s.add(each)
@@ -66,6 +161,8 @@ func (s *Set) AddUint(ii ...uint) {
 }
 
 // AddUint64 adds uint64 values ii into s.
+// Deprecated: Use NewUint64Set().Add() instead for better type safety and performance.
+// Example: uint64Set := NewUint64Set(); uint64Set.Add(1, 2, 3)
 func (s *Set) AddUint64(ii ...uint64) {
 	for _, each := range ii {
 		s.add(each)
@@ -73,6 +170,8 @@ func (s *Set) AddUint64(ii ...uint64) {
 }
 
 // AddStr adds string values ss into s.
+// Deprecated: Use NewStringSet().Add() instead for better type safety and performance.
+// Example: stringSet := NewStringSet(); stringSet.Add("a", "b", "c")
 func (s *Set) AddStr(ss ...string) {
 	for _, each := range ss {
 		s.add(each)
@@ -80,6 +179,7 @@ func (s *Set) AddStr(ss ...string) {
 }
 
 // Contains checks if i is in s.
+// Deprecated: Use TypedSet[T].Contains() instead for better type safety and performance.
 func (s *Set) Contains(i any) bool {
 	if len(s.data) == 0 {
 		return false
@@ -91,6 +191,7 @@ func (s *Set) Contains(i any) bool {
 }
 
 // Keys returns the keys in s.
+// Deprecated: Use TypedSet[T].Keys() instead for better type safety and performance.
 func (s *Set) Keys() []any {
 	var keys []any
 
@@ -102,6 +203,8 @@ func (s *Set) Keys() []any {
 }
 
 // KeysInt returns the int keys in s.
+// Deprecated: Use NewIntSet().Keys() instead for better type safety and performance.
+// The TypedSet version returns []int directly without type casting.
 func (s *Set) KeysInt() []int {
 	var keys []int
 
@@ -115,6 +218,8 @@ func (s *Set) KeysInt() []int {
 }
 
 // KeysInt64 returns int64 keys in s.
+// Deprecated: Use NewInt64Set().Keys() instead for better type safety and performance.
+// The TypedSet version returns []int64 directly without type casting.
 func (s *Set) KeysInt64() []int64 {
 	var keys []int64
 
@@ -128,6 +233,8 @@ func (s *Set) KeysInt64() []int64 {
 }
 
 // KeysUint returns uint keys in s.
+// Deprecated: Use NewUintSet().Keys() instead for better type safety and performance.
+// The TypedSet version returns []uint directly without type casting.
 func (s *Set) KeysUint() []uint {
 	var keys []uint
 
@@ -141,6 +248,9 @@ func (s *Set) KeysUint() []uint {
 }
 
 // KeysUint64 returns uint64 keys in s.
+//
+// Deprecated: Use NewUint64Set().Keys() instead for better type safety and performance.
+// The TypedSet version returns []uint64 directly without type casting.
 func (s *Set) KeysUint64() []uint64 {
 	var keys []uint64
 
@@ -154,6 +264,8 @@ func (s *Set) KeysUint64() []uint64 {
 }
 
 // KeysStr returns string keys in s.
+// Deprecated: Use NewStringSet().Keys() instead for better type safety and performance.
+// The TypedSet version returns []string directly without type casting.
 func (s *Set) KeysStr() []string {
 	var keys []string
 
@@ -167,12 +279,14 @@ func (s *Set) KeysStr() []string {
 }
 
 // Remove removes i from s.
+// Deprecated: Use TypedSet[T].Remove() instead for better type safety and performance.
 func (s *Set) Remove(i any) {
 	s.validate(i)
 	delete(s.data, i)
 }
 
 // Count returns the number of items in s.
+// Deprecated: Use TypedSet[T].Count() instead for better type safety and performance.
 func (s *Set) Count() int {
 	return len(s.data)
 }

--- a/core/collection/set.go
+++ b/core/collection/set.go
@@ -1,85 +1,45 @@
 package collection
 
-import (
-	"github.com/zeromicro/go-zero/core/lang"
-	"github.com/zeromicro/go-zero/core/logx"
-)
+import "github.com/zeromicro/go-zero/core/lang"
 
-const (
-	unmanaged = iota
-	untyped
-	intType
-	int64Type
-	uintType
-	uint64Type
-	stringType
-)
-
-// TypedSet is a type-safe generic set collection. It's not thread-safe,
-// use with synchronization for concurrent access.
-//
-// Advantages over the legacy Set:
-// - Compile-time type safety (no runtime type validation needed)
-// - Better performance (no type assertions or reflection overhead)
-// - Cleaner API (single Add method instead of multiple type-specific methods)
-// - No need for type-specific Keys methods (KeysInt, KeysStr, etc.)
-// - Zero-allocation for empty checks and direct type access
-type TypedSet[T comparable] struct {
+// Set is a type-safe generic set collection.
+// It's not thread-safe, use with synchronization for concurrent access.
+type Set[T comparable] struct {
 	data map[T]lang.PlaceholderType
 }
 
-// NewTypedSet returns a new type-safe set.
-func NewTypedSet[T comparable]() *TypedSet[T] {
-	return &TypedSet[T]{
+// NewSet returns a new type-safe set.
+func NewSet[T comparable]() *Set[T] {
+	return &Set[T]{
 		data: make(map[T]lang.PlaceholderType),
 	}
 }
 
-// NewIntSet returns a new int-typed set.
-func NewIntSet() *TypedSet[int] {
-	return NewTypedSet[int]()
-}
-
-// NewInt64Set returns a new int64-typed set.
-func NewInt64Set() *TypedSet[int64] {
-	return NewTypedSet[int64]()
-}
-
-// NewUintSet returns a new uint-typed set.
-func NewUintSet() *TypedSet[uint] {
-	return NewTypedSet[uint]()
-}
-
-// NewUint64Set returns a new uint64-typed set.
-func NewUint64Set() *TypedSet[uint64] {
-	return NewTypedSet[uint64]()
-}
-
-// NewStringSet returns a new string-typed set.
-func NewStringSet() *TypedSet[string] {
-	return NewTypedSet[string]()
-}
-
 // Add adds items to the set. Duplicates are automatically ignored.
-func (s *TypedSet[T]) Add(items ...T) {
+func (s *Set[T]) Add(items ...T) {
 	for _, item := range items {
 		s.data[item] = lang.Placeholder
 	}
 }
 
+// Clear removes all items from the set.
+func (s *Set[T]) Clear() {
+	clear(s.data)
+}
+
 // Contains checks if an item exists in the set.
-func (s *TypedSet[T]) Contains(item T) bool {
+func (s *Set[T]) Contains(item T) bool {
 	_, ok := s.data[item]
 	return ok
 }
 
-// Remove removes an item from the set.
-func (s *TypedSet[T]) Remove(item T) {
-	delete(s.data, item)
+// Count returns the number of items in the set.
+func (s *Set[T]) Count() int {
+	return len(s.data)
 }
 
 // Keys returns all elements in the set as a slice.
-func (s *TypedSet[T]) Keys() []T {
+func (s *Set[T]) Keys() []T {
 	keys := make([]T, 0, len(s.data))
 	for key := range s.data {
 		keys = append(keys, key)
@@ -87,263 +47,7 @@ func (s *TypedSet[T]) Keys() []T {
 	return keys
 }
 
-// Count returns the number of items in the set.
-func (s *TypedSet[T]) Count() int {
-	return len(s.data)
-}
-
-// Clear removes all items from the set.
-func (s *TypedSet[T]) Clear() {
-	s.data = make(map[T]lang.PlaceholderType)
-}
-
-// Set is not thread-safe, for concurrent use, make sure to use it with synchronization.
-// Deprecated: Use TypedSet[T] instead for better type safety and performance.
-// TypedSet provides compile-time type checking and eliminates the need for type-specific methods.
-type Set struct {
-	data map[any]lang.PlaceholderType
-	tp   int
-}
-
-// NewSet returns a managed Set, can only put the values with the same type.
-// Deprecated: Use NewTypedSet[T]() instead for better type safety and performance.
-// Example: NewIntSet() instead of NewSet() with AddInt()
-func NewSet() *Set {
-	return &Set{
-		data: make(map[any]lang.PlaceholderType),
-		tp:   untyped,
-	}
-}
-
-// NewUnmanagedSet returns an unmanaged Set, which can put values with different types.
-// Deprecated: Use TypedSet[any] or multiple TypedSet instances for different types instead.
-// If you really need mixed types, consider using map[any]struct{} directly.
-func NewUnmanagedSet() *Set {
-	return &Set{
-		data: make(map[any]lang.PlaceholderType),
-		tp:   unmanaged,
-	}
-}
-
-// Add adds i into s.
-// Deprecated: Use TypedSet[T].Add() instead for better type safety and performance.
-func (s *Set) Add(i ...any) {
-	for _, each := range i {
-		s.add(each)
-	}
-}
-
-// AddInt adds int values ii into s.
-// Deprecated: Use NewIntSet().Add() instead for better type safety and performance.
-// Example: intSet := NewIntSet(); intSet.Add(1, 2, 3)
-func (s *Set) AddInt(ii ...int) {
-	for _, each := range ii {
-		s.add(each)
-	}
-}
-
-// AddInt64 adds int64 values ii into s.
-// Deprecated: Use NewInt64Set().Add() instead for better type safety and performance.
-// Example: int64Set := NewInt64Set(); int64Set.Add(1, 2, 3)
-func (s *Set) AddInt64(ii ...int64) {
-	for _, each := range ii {
-		s.add(each)
-	}
-}
-
-// AddUint adds uint values ii into s.
-// Deprecated: Use NewUintSet().Add() instead for better type safety and performance.
-// Example: uintSet := NewUintSet(); uintSet.Add(1, 2, 3)
-func (s *Set) AddUint(ii ...uint) {
-	for _, each := range ii {
-		s.add(each)
-	}
-}
-
-// AddUint64 adds uint64 values ii into s.
-// Deprecated: Use NewUint64Set().Add() instead for better type safety and performance.
-// Example: uint64Set := NewUint64Set(); uint64Set.Add(1, 2, 3)
-func (s *Set) AddUint64(ii ...uint64) {
-	for _, each := range ii {
-		s.add(each)
-	}
-}
-
-// AddStr adds string values ss into s.
-// Deprecated: Use NewStringSet().Add() instead for better type safety and performance.
-// Example: stringSet := NewStringSet(); stringSet.Add("a", "b", "c")
-func (s *Set) AddStr(ss ...string) {
-	for _, each := range ss {
-		s.add(each)
-	}
-}
-
-// Contains checks if i is in s.
-// Deprecated: Use TypedSet[T].Contains() instead for better type safety and performance.
-func (s *Set) Contains(i any) bool {
-	if len(s.data) == 0 {
-		return false
-	}
-
-	s.validate(i)
-	_, ok := s.data[i]
-	return ok
-}
-
-// Keys returns the keys in s.
-// Deprecated: Use TypedSet[T].Keys() instead for better type safety and performance.
-func (s *Set) Keys() []any {
-	var keys []any
-
-	for key := range s.data {
-		keys = append(keys, key)
-	}
-
-	return keys
-}
-
-// KeysInt returns the int keys in s.
-// Deprecated: Use NewIntSet().Keys() instead for better type safety and performance.
-// The TypedSet version returns []int directly without type casting.
-func (s *Set) KeysInt() []int {
-	var keys []int
-
-	for key := range s.data {
-		if intKey, ok := key.(int); ok {
-			keys = append(keys, intKey)
-		}
-	}
-
-	return keys
-}
-
-// KeysInt64 returns int64 keys in s.
-// Deprecated: Use NewInt64Set().Keys() instead for better type safety and performance.
-// The TypedSet version returns []int64 directly without type casting.
-func (s *Set) KeysInt64() []int64 {
-	var keys []int64
-
-	for key := range s.data {
-		if intKey, ok := key.(int64); ok {
-			keys = append(keys, intKey)
-		}
-	}
-
-	return keys
-}
-
-// KeysUint returns uint keys in s.
-// Deprecated: Use NewUintSet().Keys() instead for better type safety and performance.
-// The TypedSet version returns []uint directly without type casting.
-func (s *Set) KeysUint() []uint {
-	var keys []uint
-
-	for key := range s.data {
-		if intKey, ok := key.(uint); ok {
-			keys = append(keys, intKey)
-		}
-	}
-
-	return keys
-}
-
-// KeysUint64 returns uint64 keys in s.
-//
-// Deprecated: Use NewUint64Set().Keys() instead for better type safety and performance.
-// The TypedSet version returns []uint64 directly without type casting.
-func (s *Set) KeysUint64() []uint64 {
-	var keys []uint64
-
-	for key := range s.data {
-		if intKey, ok := key.(uint64); ok {
-			keys = append(keys, intKey)
-		}
-	}
-
-	return keys
-}
-
-// KeysStr returns string keys in s.
-// Deprecated: Use NewStringSet().Keys() instead for better type safety and performance.
-// The TypedSet version returns []string directly without type casting.
-func (s *Set) KeysStr() []string {
-	var keys []string
-
-	for key := range s.data {
-		if strKey, ok := key.(string); ok {
-			keys = append(keys, strKey)
-		}
-	}
-
-	return keys
-}
-
-// Remove removes i from s.
-// Deprecated: Use TypedSet[T].Remove() instead for better type safety and performance.
-func (s *Set) Remove(i any) {
-	s.validate(i)
-	delete(s.data, i)
-}
-
-// Count returns the number of items in s.
-// Deprecated: Use TypedSet[T].Count() instead for better type safety and performance.
-func (s *Set) Count() int {
-	return len(s.data)
-}
-
-func (s *Set) add(i any) {
-	switch s.tp {
-	case unmanaged:
-		// do nothing
-	case untyped:
-		s.setType(i)
-	default:
-		s.validate(i)
-	}
-	s.data[i] = lang.Placeholder
-}
-
-func (s *Set) setType(i any) {
-	// s.tp can only be untyped here
-	switch i.(type) {
-	case int:
-		s.tp = intType
-	case int64:
-		s.tp = int64Type
-	case uint:
-		s.tp = uintType
-	case uint64:
-		s.tp = uint64Type
-	case string:
-		s.tp = stringType
-	}
-}
-
-func (s *Set) validate(i any) {
-	if s.tp == unmanaged {
-		return
-	}
-
-	switch i.(type) {
-	case int:
-		if s.tp != intType {
-			logx.Errorf("element is int, but set contains elements with type %d", s.tp)
-		}
-	case int64:
-		if s.tp != int64Type {
-			logx.Errorf("element is int64, but set contains elements with type %d", s.tp)
-		}
-	case uint:
-		if s.tp != uintType {
-			logx.Errorf("element is uint, but set contains elements with type %d", s.tp)
-		}
-	case uint64:
-		if s.tp != uint64Type {
-			logx.Errorf("element is uint64, but set contains elements with type %d", s.tp)
-		}
-	case string:
-		if s.tp != stringType {
-			logx.Errorf("element is string, but set contains elements with type %d", s.tp)
-		}
-	}
+// Remove removes an item from the set.
+func (s *Set[T]) Remove(item T) {
+	delete(s.data, item)
 }

--- a/core/collection/set_test.go
+++ b/core/collection/set_test.go
@@ -12,6 +12,105 @@ func init() {
 	logx.Disable()
 }
 
+// TypedSet functionality tests
+func TestTypedSetInt(t *testing.T) {
+	set := NewIntSet()
+	values := []int{1, 2, 3, 2, 1} // Contains duplicates
+
+	// Test adding
+	set.Add(values...)
+	assert.Equal(t, 3, set.Count()) // Should only have 3 elements after deduplication
+
+	// Test contains
+	assert.True(t, set.Contains(1))
+	assert.True(t, set.Contains(2))
+	assert.True(t, set.Contains(3))
+	assert.False(t, set.Contains(4))
+
+	// Test getting all keys
+	keys := set.Keys()
+	sort.Ints(keys)
+	assert.EqualValues(t, []int{1, 2, 3}, keys)
+
+	// Test removal
+	set.Remove(2)
+	assert.False(t, set.Contains(2))
+	assert.Equal(t, 2, set.Count())
+}
+
+func TestTypedSetStringOps(t *testing.T) {
+	set := NewStringSet()
+	values := []string{"a", "b", "c", "b", "a"}
+
+	set.Add(values...)
+	assert.Equal(t, 3, set.Count())
+
+	assert.True(t, set.Contains("a"))
+	assert.True(t, set.Contains("b"))
+	assert.True(t, set.Contains("c"))
+	assert.False(t, set.Contains("d"))
+
+	keys := set.Keys()
+	sort.Strings(keys)
+	assert.EqualValues(t, []string{"a", "b", "c"}, keys)
+}
+
+func TestTypedSetClear(t *testing.T) {
+	set := NewIntSet()
+	set.Add(1, 2, 3)
+	assert.Equal(t, 3, set.Count())
+
+	set.Clear()
+	assert.Equal(t, 0, set.Count())
+	assert.False(t, set.Contains(1))
+}
+
+func TestTypedSetEmpty(t *testing.T) {
+	set := NewIntSet()
+	assert.Equal(t, 0, set.Count())
+	assert.False(t, set.Contains(1))
+	assert.Empty(t, set.Keys())
+}
+
+func TestTypedSetMultipleTypes(t *testing.T) {
+	// Test different typed generic sets
+	intSet := NewIntSet()
+	int64Set := NewInt64Set()
+	uintSet := NewUintSet()
+	uint64Set := NewUint64Set()
+	stringSet := NewStringSet()
+
+	intSet.Add(1, 2, 3)
+	int64Set.Add(int64(1), int64(2), int64(3))
+	uintSet.Add(uint(1), uint(2), uint(3))
+	uint64Set.Add(uint64(1), uint64(2), uint64(3))
+	stringSet.Add("1", "2", "3")
+
+	assert.Equal(t, 3, intSet.Count())
+	assert.Equal(t, 3, int64Set.Count())
+	assert.Equal(t, 3, uintSet.Count())
+	assert.Equal(t, 3, uint64Set.Count())
+	assert.Equal(t, 3, stringSet.Count())
+}
+
+// TypedSet benchmarks
+func BenchmarkTypedIntSet(b *testing.B) {
+	s := NewIntSet()
+	for i := 0; i < b.N; i++ {
+		s.Add(i)
+		_ = s.Contains(i)
+	}
+}
+
+func BenchmarkTypedStringSet(b *testing.B) {
+	s := NewStringSet()
+	for i := 0; i < b.N; i++ {
+		s.Add(string(rune(i)))
+		_ = s.Contains(string(rune(i)))
+	}
+}
+
+// Legacy tests remain unchanged for backward compatibility
 func BenchmarkRawSet(b *testing.B) {
 	m := make(map[any]struct{})
 	for i := 0; i < b.N; i++ {

--- a/core/collection/set_test.go
+++ b/core/collection/set_test.go
@@ -12,9 +12,9 @@ func init() {
 	logx.Disable()
 }
 
-// TypedSet functionality tests
+// Set functionality tests
 func TestTypedSetInt(t *testing.T) {
-	set := NewIntSet()
+	set := NewSet[int]()
 	values := []int{1, 2, 3, 2, 1} // Contains duplicates
 
 	// Test adding
@@ -39,7 +39,7 @@ func TestTypedSetInt(t *testing.T) {
 }
 
 func TestTypedSetStringOps(t *testing.T) {
-	set := NewStringSet()
+	set := NewSet[string]()
 	values := []string{"a", "b", "c", "b", "a"}
 
 	set.Add(values...)
@@ -56,7 +56,7 @@ func TestTypedSetStringOps(t *testing.T) {
 }
 
 func TestTypedSetClear(t *testing.T) {
-	set := NewIntSet()
+	set := NewSet[int]()
 	set.Add(1, 2, 3)
 	assert.Equal(t, 3, set.Count())
 
@@ -66,7 +66,7 @@ func TestTypedSetClear(t *testing.T) {
 }
 
 func TestTypedSetEmpty(t *testing.T) {
-	set := NewIntSet()
+	set := NewSet[int]()
 	assert.Equal(t, 0, set.Count())
 	assert.False(t, set.Contains(1))
 	assert.Empty(t, set.Keys())
@@ -74,16 +74,16 @@ func TestTypedSetEmpty(t *testing.T) {
 
 func TestTypedSetMultipleTypes(t *testing.T) {
 	// Test different typed generic sets
-	intSet := NewIntSet()
-	int64Set := NewInt64Set()
-	uintSet := NewUintSet()
-	uint64Set := NewUint64Set()
-	stringSet := NewStringSet()
+	intSet := NewSet[int]()
+	int64Set := NewSet[int64]()
+	uintSet := NewSet[uint]()
+	uint64Set := NewSet[uint64]()
+	stringSet := NewSet[string]()
 
 	intSet.Add(1, 2, 3)
-	int64Set.Add(int64(1), int64(2), int64(3))
-	uintSet.Add(uint(1), uint(2), uint(3))
-	uint64Set.Add(uint64(1), uint64(2), uint64(3))
+	int64Set.Add(1, 2, 3)
+	uintSet.Add(1, 2, 3)
+	uint64Set.Add(1, 2, 3)
 	stringSet.Add("1", "2", "3")
 
 	assert.Equal(t, 3, intSet.Count())
@@ -93,9 +93,9 @@ func TestTypedSetMultipleTypes(t *testing.T) {
 	assert.Equal(t, 3, stringSet.Count())
 }
 
-// TypedSet benchmarks
+// Set benchmarks
 func BenchmarkTypedIntSet(b *testing.B) {
-	s := NewIntSet()
+	s := NewSet[int]()
 	for i := 0; i < b.N; i++ {
 		s.Add(i)
 		_ = s.Contains(i)
@@ -103,7 +103,7 @@ func BenchmarkTypedIntSet(b *testing.B) {
 }
 
 func BenchmarkTypedStringSet(b *testing.B) {
-	s := NewStringSet()
+	s := NewSet[string]()
 	for i := 0; i < b.N; i++ {
 		s.Add(string(rune(i)))
 		_ = s.Contains(string(rune(i)))
@@ -119,26 +119,10 @@ func BenchmarkRawSet(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmanagedSet(b *testing.B) {
-	s := NewUnmanagedSet()
-	for i := 0; i < b.N; i++ {
-		s.Add(i)
-		_ = s.Contains(i)
-	}
-}
-
-func BenchmarkSet(b *testing.B) {
-	s := NewSet()
-	for i := 0; i < b.N; i++ {
-		s.AddInt(i)
-		_ = s.Contains(i)
-	}
-}
-
 func TestAdd(t *testing.T) {
 	// given
-	set := NewUnmanagedSet()
-	values := []any{1, 2, 3}
+	set := NewSet[int]()
+	values := []int{1, 2, 3}
 
 	// when
 	set.Add(values...)
@@ -150,82 +134,74 @@ func TestAdd(t *testing.T) {
 
 func TestAddInt(t *testing.T) {
 	// given
-	set := NewSet()
+	set := NewSet[int]()
 	values := []int{1, 2, 3}
 
 	// when
-	set.AddInt(values...)
+	set.Add(values...)
 
 	// then
 	assert.True(t, set.Contains(1) && set.Contains(2) && set.Contains(3))
-	keys := set.KeysInt()
+	keys := set.Keys()
 	sort.Ints(keys)
 	assert.EqualValues(t, values, keys)
 }
 
 func TestAddInt64(t *testing.T) {
 	// given
-	set := NewSet()
+	set := NewSet[int64]()
 	values := []int64{1, 2, 3}
 
 	// when
-	set.AddInt64(values...)
+	set.Add(values...)
 
 	// then
-	assert.True(t, set.Contains(int64(1)) && set.Contains(int64(2)) && set.Contains(int64(3)))
-	assert.Equal(t, len(values), len(set.KeysInt64()))
+	assert.True(t, set.Contains(1) && set.Contains(2) && set.Contains(3))
+	assert.Equal(t, len(values), len(set.Keys()))
 }
 
 func TestAddUint(t *testing.T) {
 	// given
-	set := NewSet()
+	set := NewSet[uint]()
 	values := []uint{1, 2, 3}
 
 	// when
-	set.AddUint(values...)
+	set.Add(values...)
 
 	// then
-	assert.True(t, set.Contains(uint(1)) && set.Contains(uint(2)) && set.Contains(uint(3)))
-	assert.Equal(t, len(values), len(set.KeysUint()))
+	assert.True(t, set.Contains(1) && set.Contains(2) && set.Contains(3))
+	assert.Equal(t, len(values), len(set.Keys()))
 }
 
 func TestAddUint64(t *testing.T) {
 	// given
-	set := NewSet()
+	set := NewSet[uint64]()
 	values := []uint64{1, 2, 3}
 
 	// when
-	set.AddUint64(values...)
+	set.Add(values...)
 
 	// then
-	assert.True(t, set.Contains(uint64(1)) && set.Contains(uint64(2)) && set.Contains(uint64(3)))
-	assert.Equal(t, len(values), len(set.KeysUint64()))
+	assert.True(t, set.Contains(1) && set.Contains(2) && set.Contains(3))
+	assert.Equal(t, len(values), len(set.Keys()))
 }
 
 func TestAddStr(t *testing.T) {
 	// given
-	set := NewSet()
+	set := NewSet[string]()
 	values := []string{"1", "2", "3"}
 
 	// when
-	set.AddStr(values...)
+	set.Add(values...)
 
 	// then
 	assert.True(t, set.Contains("1") && set.Contains("2") && set.Contains("3"))
-	assert.Equal(t, len(values), len(set.KeysStr()))
+	assert.Equal(t, len(values), len(set.Keys()))
 }
 
 func TestContainsWithoutElements(t *testing.T) {
 	// given
-	set := NewSet()
-
-	// then
-	assert.False(t, set.Contains(1))
-}
-
-func TestContainsUnmanagedWithoutElements(t *testing.T) {
-	// given
-	set := NewUnmanagedSet()
+	set := NewSet[int]()
 
 	// then
 	assert.False(t, set.Contains(1))
@@ -233,8 +209,8 @@ func TestContainsUnmanagedWithoutElements(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	// given
-	set := NewSet()
-	set.Add([]any{1, 2, 3}...)
+	set := NewSet[int]()
+	set.Add([]int{1, 2, 3}...)
 
 	// when
 	set.Remove(2)
@@ -245,57 +221,9 @@ func TestRemove(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	// given
-	set := NewSet()
-	set.Add([]any{1, 2, 3}...)
+	set := NewSet[int]()
+	set.Add([]int{1, 2, 3}...)
 
 	// then
 	assert.Equal(t, set.Count(), 3)
-}
-
-func TestKeysIntMismatch(t *testing.T) {
-	set := NewSet()
-	set.add(int64(1))
-	set.add(2)
-	vals := set.KeysInt()
-	assert.EqualValues(t, []int{2}, vals)
-}
-
-func TestKeysInt64Mismatch(t *testing.T) {
-	set := NewSet()
-	set.add(1)
-	set.add(int64(2))
-	vals := set.KeysInt64()
-	assert.EqualValues(t, []int64{2}, vals)
-}
-
-func TestKeysUintMismatch(t *testing.T) {
-	set := NewSet()
-	set.add(1)
-	set.add(uint(2))
-	vals := set.KeysUint()
-	assert.EqualValues(t, []uint{2}, vals)
-}
-
-func TestKeysUint64Mismatch(t *testing.T) {
-	set := NewSet()
-	set.add(1)
-	set.add(uint64(2))
-	vals := set.KeysUint64()
-	assert.EqualValues(t, []uint64{2}, vals)
-}
-
-func TestKeysStrMismatch(t *testing.T) {
-	set := NewSet()
-	set.add(1)
-	set.add("2")
-	vals := set.KeysStr()
-	assert.EqualValues(t, []string{"2"}, vals)
-}
-
-func TestSetType(t *testing.T) {
-	set := NewUnmanagedSet()
-	set.add(1)
-	set.add("2")
-	vals := set.Keys()
-	assert.ElementsMatch(t, []any{1, "2"}, vals)
 }

--- a/core/logx/fields.go
+++ b/core/logx/fields.go
@@ -7,12 +7,11 @@ import (
 )
 
 var (
-	fieldsContextKey contextKey
 	globalFields     atomic.Value
 	globalFieldsLock sync.Mutex
 )
 
-type contextKey struct{}
+type fieldsKey struct{}
 
 // AddGlobalFields adds global fields.
 func AddGlobalFields(fields ...LogField) {
@@ -29,16 +28,16 @@ func AddGlobalFields(fields ...LogField) {
 
 // ContextWithFields returns a new context with the given fields.
 func ContextWithFields(ctx context.Context, fields ...LogField) context.Context {
-	if val := ctx.Value(fieldsContextKey); val != nil {
+	if val := ctx.Value(fieldsKey{}); val != nil {
 		if arr, ok := val.([]LogField); ok {
 			allFields := make([]LogField, 0, len(arr)+len(fields))
 			allFields = append(allFields, arr...)
 			allFields = append(allFields, fields...)
-			return context.WithValue(ctx, fieldsContextKey, allFields)
+			return context.WithValue(ctx, fieldsKey{}, allFields)
 		}
 	}
 
-	return context.WithValue(ctx, fieldsContextKey, fields)
+	return context.WithValue(ctx, fieldsKey{}, fields)
 }
 
 // WithFields returns a new logger with the given fields.

--- a/core/logx/fields_test.go
+++ b/core/logx/fields_test.go
@@ -34,7 +34,7 @@ func TestAddGlobalFields(t *testing.T) {
 
 func TestContextWithFields(t *testing.T) {
 	ctx := ContextWithFields(context.Background(), Field("a", 1), Field("b", 2))
-	vals := ctx.Value(fieldsContextKey)
+	vals := ctx.Value(fieldsKey{})
 	assert.NotNil(t, vals)
 	fields, ok := vals.([]LogField)
 	assert.True(t, ok)
@@ -43,7 +43,7 @@ func TestContextWithFields(t *testing.T) {
 
 func TestWithFields(t *testing.T) {
 	ctx := WithFields(context.Background(), Field("a", 1), Field("b", 2))
-	vals := ctx.Value(fieldsContextKey)
+	vals := ctx.Value(fieldsKey{})
 	assert.NotNil(t, vals)
 	fields, ok := vals.([]LogField)
 	assert.True(t, ok)
@@ -55,7 +55,7 @@ func TestWithFieldsAppend(t *testing.T) {
 	ctx := context.WithValue(context.Background(), dummyKey, "dummy")
 	ctx = ContextWithFields(ctx, Field("a", 1), Field("b", 2))
 	ctx = ContextWithFields(ctx, Field("c", 3), Field("d", 4))
-	vals := ctx.Value(fieldsContextKey)
+	vals := ctx.Value(fieldsKey{})
 	assert.NotNil(t, vals)
 	fields, ok := vals.([]LogField)
 	assert.True(t, ok)
@@ -80,8 +80,8 @@ func TestWithFieldsAppendCopy(t *testing.T) {
 	ctxa := ContextWithFields(ctx, af)
 	ctxb := ContextWithFields(ctx, bf)
 
-	assert.EqualValues(t, af, ctxa.Value(fieldsContextKey).([]LogField)[count])
-	assert.EqualValues(t, bf, ctxb.Value(fieldsContextKey).([]LogField)[count])
+	assert.EqualValues(t, af, ctxa.Value(fieldsKey{}).([]LogField)[count])
+	assert.EqualValues(t, bf, ctxb.Value(fieldsKey{}).([]LogField)[count])
 }
 
 func BenchmarkAtomicValue(b *testing.B) {

--- a/core/logx/richlogger.go
+++ b/core/logx/richlogger.go
@@ -224,7 +224,7 @@ func (l *richLogger) buildFields(fields ...LogField) []LogField {
 		fields = append(fields, Field(spanKey, spanID))
 	}
 
-	val := l.ctx.Value(fieldsContextKey)
+	val := l.ctx.Value(fieldsKey{})
 	if val != nil {
 		if arr, ok := val.([]LogField); ok {
 			fields = append(fields, arr...)

--- a/core/logx/sensitive.go
+++ b/core/logx/sensitive.go
@@ -1,0 +1,21 @@
+package logx
+
+// Sensitive is an interface that defines a method for masking sensitive information in logs.
+// It is typically implemented by types that contain sensitive data,
+// such as passwords or personal information.
+// Infov, Errorv, Debugv, and Slowv methods will call this method to mask sensitive data.
+// The values in LogField will also be masked if they implement the Sensitive interface.
+type Sensitive interface {
+	// MaskSensitive masks sensitive information in the log.
+	MaskSensitive() any
+}
+
+// maskSensitive returns the value returned by MaskSensitive method,
+// if the value implements Sensitive interface.
+func maskSensitive(v any) any {
+	if s, ok := v.(Sensitive); ok {
+		return s.MaskSensitive()
+	}
+
+	return v
+}

--- a/core/logx/sensitive_test.go
+++ b/core/logx/sensitive_test.go
@@ -1,0 +1,50 @@
+package logx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const maskedContent = "******"
+
+type User struct {
+	Name string
+	Pass string
+}
+
+func (u User) MaskSensitive() any {
+	return User{
+		Name: u.Name,
+		Pass: maskedContent,
+	}
+}
+
+type NonSensitiveUser struct {
+	Name string
+	Pass string
+}
+
+func TestMaskSensitive(t *testing.T) {
+	t.Run("sensitive", func(t *testing.T) {
+		user := User{
+			Name: "kevin",
+			Pass: "123",
+		}
+
+		mu := maskSensitive(user)
+		assert.Equal(t, user.Name, mu.(User).Name)
+		assert.Equal(t, maskedContent, mu.(User).Pass)
+	})
+
+	t.Run("non-sensitive", func(t *testing.T) {
+		user := NonSensitiveUser{
+			Name: "kevin",
+			Pass: "123",
+		}
+
+		mu := maskSensitive(user)
+		assert.Equal(t, user.Name, mu.(NonSensitiveUser).Name)
+		assert.Equal(t, user.Pass, mu.(NonSensitiveUser).Pass)
+	})
+}

--- a/core/mapping/unmarshaler.go
+++ b/core/mapping/unmarshaler.go
@@ -766,8 +766,8 @@ func (u *Unmarshaler) processFieldWithEnvValue(fieldType reflect.Type, value ref
 	}
 
 	fieldKind := fieldType.Kind()
-	switch fieldKind {
-	case reflect.Bool:
+	switch true {
+	case fieldKind == reflect.Bool:
 		val, err := strconv.ParseBool(envVal)
 		if err != nil {
 			return fmt.Errorf("unmarshal field %q with environment variable, %w", fullName, err)
@@ -775,13 +775,13 @@ func (u *Unmarshaler) processFieldWithEnvValue(fieldType reflect.Type, value ref
 
 		value.SetBool(val)
 		return nil
-	case durationType.Kind():
+	case fieldType == durationType:
 		if err := fillDurationValue(fieldType, value, envVal); err != nil {
 			return fmt.Errorf("unmarshal field %q with environment variable, %w", fullName, err)
 		}
 
 		return nil
-	case reflect.String:
+	case fieldKind == reflect.String:
 		value.SetString(envVal)
 		return nil
 	default:

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -4679,6 +4679,23 @@ func TestUnmarshal_EnvInt(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_EnvInt64(t *testing.T) {
+	type Value struct {
+		Age int64 `key:"age,env=TEST_NAME_INT64"`
+	}
+
+	const (
+		envName = "TEST_NAME_INT64"
+		envVal  = "88"
+	)
+	t.Setenv(envName, envVal)
+
+	var v Value
+	if assert.NoError(t, UnmarshalKey(emptyMap, &v)) {
+		assert.Equal(t, int64(88), v.Age)
+	}
+}
+
 func TestUnmarshal_EnvIntOverwrite(t *testing.T) {
 	type Value struct {
 		Age int `key:"age,env=TEST_NAME_INT"`

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -4801,20 +4801,33 @@ func TestUnmarshal_EnvBoolBad(t *testing.T) {
 }
 
 func TestUnmarshal_EnvDuration(t *testing.T) {
-	type Value struct {
-		Duration time.Duration `key:"duration,env=TEST_NAME_DURATION"`
-	}
-
 	const (
 		envName = "TEST_NAME_DURATION"
 		envVal  = "1s"
 	)
 	t.Setenv(envName, envVal)
 
-	var v Value
-	if assert.NoError(t, UnmarshalKey(emptyMap, &v)) {
-		assert.Equal(t, time.Second, v.Duration)
-	}
+	t.Run("valid duration", func(t *testing.T) {
+		type Value struct {
+			Duration time.Duration `key:"duration,env=TEST_NAME_DURATION"`
+		}
+
+		var v Value
+		if assert.NoError(t, UnmarshalKey(emptyMap, &v)) {
+			assert.Equal(t, time.Second, v.Duration)
+		}
+	})
+
+	t.Run("ptr of duration", func(t *testing.T) {
+		type Value struct {
+			Duration *time.Duration `key:"duration,env=TEST_NAME_DURATION"`
+		}
+
+		var v Value
+		if assert.NoError(t, UnmarshalKey(emptyMap, &v)) {
+			assert.Equal(t, time.Second, *v.Duration)
+		}
+	})
 }
 
 func TestUnmarshal_EnvDurationBadValue(t *testing.T) {

--- a/core/mapping/unmarshaler_test.go
+++ b/core/mapping/unmarshaler_test.go
@@ -6083,6 +6083,105 @@ func TestParseJsonStringValue(t *testing.T) {
 	})
 }
 
+// issue #5033, string type
+func TestUnmarshalFromEnvString(t *testing.T) {
+	t.Setenv("STRING_ENV", "dev")
+
+	t.Run("by value", func(t *testing.T) {
+		type (
+			Env    string
+			Config struct {
+				Env Env `json:",env=STRING_ENV,default=prod"`
+			}
+		)
+
+		var c Config
+		if assert.NoError(t, UnmarshalJsonMap(map[string]any{}, &c)) {
+			assert.Equal(t, Env("dev"), c.Env)
+		}
+	})
+
+	t.Run("by ptr", func(t *testing.T) {
+		type (
+			Env    string
+			Config struct {
+				Env *Env `json:",env=STRING_ENV,default=prod"`
+			}
+		)
+
+		var c Config
+		if assert.NoError(t, UnmarshalJsonMap(map[string]any{}, &c)) {
+			assert.Equal(t, Env("dev"), *c.Env)
+		}
+	})
+}
+
+// issue #5033, bool type
+func TestUnmarshalFromEnvBool(t *testing.T) {
+	t.Setenv("BOOL_ENV", "true")
+
+	t.Run("by value", func(t *testing.T) {
+		type (
+			Env    bool
+			Config struct {
+				Env Env `json:",env=BOOL_ENV,default=false"`
+			}
+		)
+
+		var c Config
+		if assert.NoError(t, UnmarshalJsonMap(map[string]any{}, &c)) {
+			assert.Equal(t, Env(true), c.Env)
+		}
+	})
+
+	t.Run("by ptr", func(t *testing.T) {
+		type (
+			Env    bool
+			Config struct {
+				Env *Env `json:",env=BOOL_ENV,default=false"`
+			}
+		)
+
+		var c Config
+		if assert.NoError(t, UnmarshalJsonMap(map[string]any{}, &c)) {
+			assert.Equal(t, Env(true), *c.Env)
+		}
+	})
+}
+
+// issue #5033, customized int type
+func TestUnmarshalFromEnvInt(t *testing.T) {
+	t.Setenv("INT_ENV", "2")
+
+	t.Run("by value", func(t *testing.T) {
+		type (
+			Env    int
+			Config struct {
+				Env Env `json:",env=INT_ENV,default=0"`
+			}
+		)
+
+		var c Config
+		if assert.NoError(t, UnmarshalJsonMap(map[string]any{}, &c)) {
+			assert.Equal(t, Env(2), c.Env)
+		}
+	})
+
+	t.Run("by ptr", func(t *testing.T) {
+		type (
+			Env    int
+			Config struct {
+				Env *Env `json:",env=INT_ENV,default=0"`
+			}
+		)
+
+		var c Config
+		if assert.NoError(t, UnmarshalJsonMap(map[string]any{}, &c)) {
+			assert.Equal(t, Env(2), *c.Env)
+		}
+	})
+}
+
 func BenchmarkDefaultValue(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var a struct {

--- a/core/mapping/utils.go
+++ b/core/mapping/utils.go
@@ -583,6 +583,10 @@ func toFloat64(v any) (float64, bool) {
 	}
 }
 
+func toReflectValue(tp reflect.Type, v any) reflect.Value {
+	return reflect.ValueOf(v).Convert(Deref(tp))
+}
+
 func usingDifferentKeys(key string, field reflect.StructField) bool {
 	if len(field.Tag) > 0 {
 		if _, ok := field.Tag.Lookup(key); !ok {

--- a/core/mr/mapreduce_test.go
+++ b/core/mr/mapreduce_test.go
@@ -39,6 +39,36 @@ func TestFinish(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestFinishWithPartialErrors(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	errDummy := errors.New("dummy")
+
+	t.Run("one error", func(t *testing.T) {
+		err := Finish(func() error {
+			return errDummy
+		}, func() error {
+			return nil
+		}, func() error {
+			return nil
+		})
+
+		assert.Equal(t, errDummy, err)
+	})
+
+	t.Run("two errors", func(t *testing.T) {
+		err := Finish(func() error {
+			return errDummy
+		}, func() error {
+			return errDummy
+		}, func() error {
+			return nil
+		})
+
+		assert.Equal(t, errDummy, err)
+	})
+}
+
 func TestFinishNone(t *testing.T) {
 	defer goleak.VerifyNone(t)
 

--- a/core/stores/sqlx/config.go
+++ b/core/stores/sqlx/config.go
@@ -1,0 +1,29 @@
+package sqlx
+
+import "errors"
+
+var (
+	errEmptyDatasource = errors.New("empty datasource")
+	errEmptyDriverName = errors.New("empty driver name")
+)
+
+// SqlConf defines the configuration for sqlx.
+type SqlConf struct {
+	DataSource string
+	DriverName string   `json:",default=mysql"`
+	Replicas   []string `json:",optional"`
+	Policy     string   `json:",default=round-robin,options=round-robin|random"`
+}
+
+// Validate validates the SqlxConf.
+func (sc SqlConf) Validate() error {
+	if len(sc.DataSource) == 0 {
+		return errEmptyDatasource
+	}
+
+	if len(sc.DriverName) == 0 {
+		return errEmptyDriverName
+	}
+
+	return nil
+}

--- a/core/stores/sqlx/config_test.go
+++ b/core/stores/sqlx/config_test.go
@@ -1,0 +1,29 @@
+package sqlx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/conf"
+)
+
+func TestValidate(t *testing.T) {
+	text := []byte(`DataSource: primary:password@tcp(127.0.0.1:3306)/primary_db
+`)
+
+	var sc SqlConf
+	err := conf.LoadFromYamlBytes(text, &sc)
+	assert.Nil(t, err)
+	assert.Equal(t, "mysql", sc.DriverName)
+	assert.Equal(t, policyRoundRobin, sc.Policy)
+	assert.Nil(t, sc.Validate())
+
+	sc = SqlConf{}
+	assert.Equal(t, errEmptyDatasource, sc.Validate())
+
+	sc.DataSource = "primary:password@tcp(127.0.0.1:3306)/primary_db"
+	assert.Equal(t, errEmptyDriverName, sc.Validate())
+
+	sc.DriverName = "mysql"
+	assert.Nil(t, sc.Validate())
+}

--- a/core/stores/sqlx/orm.go
+++ b/core/stores/sqlx/orm.go
@@ -279,6 +279,11 @@ func unwrapFields(v reflect.Value) []reflect.Value {
 		if child.Kind() == reflect.Struct && childType.Anonymous {
 			fields = append(fields, unwrapFields(child)...)
 		} else {
+			key := parseTagName(childType)
+			if key == "-" {
+				continue
+			}
+
 			fields = append(fields, child)
 		}
 	}

--- a/core/stores/sqlx/orm.go
+++ b/core/stores/sqlx/orm.go
@@ -9,7 +9,10 @@ import (
 	"github.com/zeromicro/go-zero/core/mapping"
 )
 
-const tagName = "db"
+const (
+	tagIgnore = "-"
+	tagName   = "db"
+)
 
 var (
 	// ErrNotMatchDestination is an error that indicates not matching destination to scan.
@@ -269,21 +272,20 @@ func unwrapFields(v reflect.Value) []reflect.Value {
 			continue
 		}
 
+		childType := indirect.Type().Field(i)
+		if parseTagName(childType) == tagIgnore {
+			continue
+		}
+
 		if child.Kind() == reflect.Ptr && child.IsNil() {
 			baseValueType := mapping.Deref(child.Type())
 			child.Set(reflect.New(baseValueType))
 		}
 
 		child = reflect.Indirect(child)
-		childType := indirect.Type().Field(i)
 		if child.Kind() == reflect.Struct && childType.Anonymous {
 			fields = append(fields, unwrapFields(child)...)
 		} else {
-			key := parseTagName(childType)
-			if key == "-" {
-				continue
-			}
-
 			fields = append(fields, child)
 		}
 	}

--- a/core/stores/sqlx/orm_test.go
+++ b/core/stores/sqlx/orm_test.go
@@ -14,7 +14,8 @@ import (
 func TestUnmarshalRowBool(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value bool
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -25,7 +26,8 @@ func TestUnmarshalRowBool(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value struct {
 			Value bool `db:"value"`
@@ -39,7 +41,8 @@ func TestUnmarshalRowBool(t *testing.T) {
 func TestUnmarshalRowBoolNotSettable(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value bool
 		assert.NotNil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -51,7 +54,8 @@ func TestUnmarshalRowBoolNotSettable(t *testing.T) {
 func TestUnmarshalRowInt(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value int
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -64,7 +68,8 @@ func TestUnmarshalRowInt(t *testing.T) {
 func TestUnmarshalRowInt8(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value int8
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -77,7 +82,8 @@ func TestUnmarshalRowInt8(t *testing.T) {
 func TestUnmarshalRowInt16(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("4")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value int16
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -90,7 +96,8 @@ func TestUnmarshalRowInt16(t *testing.T) {
 func TestUnmarshalRowInt32(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value int32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -103,7 +110,8 @@ func TestUnmarshalRowInt32(t *testing.T) {
 func TestUnmarshalRowInt64(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("6")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value int64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -116,7 +124,8 @@ func TestUnmarshalRowInt64(t *testing.T) {
 func TestUnmarshalRowUint(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value uint
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -129,7 +138,8 @@ func TestUnmarshalRowUint(t *testing.T) {
 func TestUnmarshalRowUint8(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value uint8
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -142,7 +152,8 @@ func TestUnmarshalRowUint8(t *testing.T) {
 func TestUnmarshalRowUint16(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("4")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value uint16
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -155,7 +166,8 @@ func TestUnmarshalRowUint16(t *testing.T) {
 func TestUnmarshalRowUint32(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value uint32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -168,7 +180,8 @@ func TestUnmarshalRowUint32(t *testing.T) {
 func TestUnmarshalRowUint64(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("6")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value uint64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -181,7 +194,8 @@ func TestUnmarshalRowUint64(t *testing.T) {
 func TestUnmarshalRowFloat32(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("7")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value float32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -194,7 +208,8 @@ func TestUnmarshalRowFloat32(t *testing.T) {
 func TestUnmarshalRowFloat64(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("8")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value float64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -208,7 +223,8 @@ func TestUnmarshalRowString(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		const expect = "hello"
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString(expect)
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value string
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -226,7 +242,8 @@ func TestUnmarshalRowStruct(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -243,7 +260,8 @@ func TestUnmarshalRowStruct(t *testing.T) {
 
 		errAny := errors.New("any error")
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, &mockedScanner{
@@ -260,7 +278,8 @@ func TestUnmarshalRowStruct(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -274,7 +293,8 @@ func TestUnmarshalRowStruct(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -283,7 +303,8 @@ func TestUnmarshalRowStruct(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("8")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		type myString chan int
 		var value myString
@@ -301,7 +322,8 @@ func TestUnmarshalRowStructWithTags(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -317,7 +339,8 @@ func TestUnmarshalRowStructWithTags(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -331,7 +354,8 @@ func TestUnmarshalRowStructWithTags(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -345,7 +369,8 @@ func TestUnmarshalRowStructWithTags(t *testing.T) {
 		}
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(&value, rows, true)
@@ -361,7 +386,8 @@ func TestUnmarshalRowStructWithTags(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -379,7 +405,8 @@ func TestUnmarshalRowStructWithTagsIgnoreFields(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -394,7 +421,8 @@ func TestUnmarshalRowStructWithTagsIgnoreFields(t *testing.T) {
 		})
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -411,7 +439,8 @@ func TestUnmarshalRowStructWithTagsWrongColumns(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name"}).FromCSVString("liao")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		assert.NotNil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRow(value, rows, true)
@@ -423,7 +452,8 @@ func TestUnmarshalRowsBool(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []bool{true, false}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1\n0")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []bool
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -434,7 +464,8 @@ func TestUnmarshalRowsBool(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1\n0")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []bool
 		assert.Error(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -444,7 +475,8 @@ func TestUnmarshalRowsBool(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1\n0")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value struct {
 			value []bool `db:"value"`
@@ -456,7 +488,8 @@ func TestUnmarshalRowsBool(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1\n0")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []bool
 		errAny := errors.New("any")
@@ -473,7 +506,8 @@ func TestUnmarshalRowsInt(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []int{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []int
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -487,7 +521,8 @@ func TestUnmarshalRowsInt8(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []int8{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []int8
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -501,7 +536,8 @@ func TestUnmarshalRowsInt16(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []int16{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []int16
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -515,7 +551,8 @@ func TestUnmarshalRowsInt32(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []int32{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []int32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -529,7 +566,8 @@ func TestUnmarshalRowsInt64(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []int64{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []int64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -543,7 +581,8 @@ func TestUnmarshalRowsUint(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []uint{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []uint
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -557,7 +596,8 @@ func TestUnmarshalRowsUint8(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []uint8{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []uint8
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -571,7 +611,8 @@ func TestUnmarshalRowsUint16(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []uint16{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []uint16
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -585,7 +626,8 @@ func TestUnmarshalRowsUint32(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []uint32{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []uint32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -599,7 +641,8 @@ func TestUnmarshalRowsUint64(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []uint64{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []uint64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -613,7 +656,8 @@ func TestUnmarshalRowsFloat32(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []float32{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []float32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -627,7 +671,8 @@ func TestUnmarshalRowsFloat64(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []float64{2, 3}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []float64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -641,7 +686,8 @@ func TestUnmarshalRowsString(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []string{"hello", "world"}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("hello\nworld")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []string
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -657,7 +703,8 @@ func TestUnmarshalRowsBoolPtr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*bool{&yes, &no}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("1\n0")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*bool
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -673,7 +720,8 @@ func TestUnmarshalRowsIntPtr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*int{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*int
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -689,7 +737,8 @@ func TestUnmarshalRowsInt8Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*int8{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*int8
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -705,7 +754,8 @@ func TestUnmarshalRowsInt16Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*int16{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*int16
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -721,7 +771,8 @@ func TestUnmarshalRowsInt32Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*int32{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*int32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -737,7 +788,8 @@ func TestUnmarshalRowsInt64Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*int64{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*int64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -753,7 +805,8 @@ func TestUnmarshalRowsUintPtr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*uint{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*uint
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -769,7 +822,8 @@ func TestUnmarshalRowsUint8Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*uint8{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*uint8
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -785,7 +839,8 @@ func TestUnmarshalRowsUint16Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*uint16{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*uint16
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -801,7 +856,8 @@ func TestUnmarshalRowsUint32Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*uint32{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*uint32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -817,7 +873,8 @@ func TestUnmarshalRowsUint64Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*uint64{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*uint64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -833,7 +890,8 @@ func TestUnmarshalRowsFloat32Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*float32{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*float32
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -849,7 +907,8 @@ func TestUnmarshalRowsFloat64Ptr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*float64{&two, &three}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("2\n3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*float64
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -865,7 +924,8 @@ func TestUnmarshalRowsStringPtr(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expect := []*string{&hello, &world}
 		rs := sqlmock.NewRows([]string{"value"}).FromCSVString("hello\nworld")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var value []*string
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
@@ -896,7 +956,8 @@ func TestUnmarshalRowsStruct(t *testing.T) {
 		}
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -915,7 +976,8 @@ func TestUnmarshalRowsStruct(t *testing.T) {
 
 		errAny := errors.New("any error")
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, &mockedScanner{
 				colErr: errAny,
@@ -932,7 +994,8 @@ func TestUnmarshalRowsStruct(t *testing.T) {
 
 		errAny := errors.New("any error")
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, &mockedScanner{
 				cols:    []string{"name", "age"},
@@ -947,7 +1010,8 @@ func TestUnmarshalRowsStruct(t *testing.T) {
 
 		errAny := errors.New("any error")
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, &mockedScanner{
 				cols:    []string{"name", "age"},
@@ -986,7 +1050,8 @@ func TestUnmarshalRowsStructWithNullStringType(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "value"}).AddRow(
 			"first", "firstnullstring").AddRow("second", nil)
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -1020,7 +1085,8 @@ func TestUnmarshalRowsStructWithTags(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -1058,7 +1124,8 @@ func TestUnmarshalRowsStructWithTagsIgnoreFields(t *testing.T) {
 		}
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"), ErrNotMatchDestination)
@@ -1072,7 +1139,8 @@ func TestUnmarshalRowsStructWithTagsIgnoreFields(t *testing.T) {
 		}
 
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -1113,7 +1181,8 @@ func TestUnmarshalRowsStructAndEmbeddedAnonymousStructWithTags(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "age", "value"}).FromCSVString("first,2,3\nsecond,3,4")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age, value from users where user=?", "anyone"))
@@ -1155,7 +1224,8 @@ func TestUnmarshalRowsStructAndEmbeddedStructPtrAnonymousWithTags(t *testing.T) 
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "age", "value"}).FromCSVString("first,2,3\nsecond,3,4")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age, value from users where user=?", "anyone"))
@@ -1189,7 +1259,8 @@ func TestUnmarshalRowsStructPtr(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -1222,7 +1293,8 @@ func TestUnmarshalRowsStructWithTagsPtr(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -1255,7 +1327,8 @@ func TestUnmarshalRowsStructWithTagsPtrWithInnerPtr(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
 			return unmarshalRows(&value, rows, true)
 		}, "select name, age from users where user=?", "anyone"))
@@ -1270,7 +1343,8 @@ func TestUnmarshalRowsStructWithTagsPtrWithInnerPtr(t *testing.T) {
 func TestCommonSqlConn_QueryRowOptional(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rs := sqlmock.NewRows([]string{"age"}).FromCSVString("5")
-		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
 
 		var r struct {
 			User string `db:"user"`
@@ -1320,8 +1394,8 @@ func TestUnmarshalRowError(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 				rs := sqlmock.NewRows([]string{"age"}).FromCSVString("5")
-				mock.ExpectQuery("select (.+) from users where user=?").WithArgs(
-					"anyone").WillReturnRows(rs)
+				mock.ExpectQuery("select (.+) from users where user=?").
+					WithArgs("anyone").WillReturnRows(rs)
 
 				var r struct {
 					User string `db:"user"`
@@ -1499,6 +1573,34 @@ func TestAnonymousStructPrError(t *testing.T) {
 			assert.Equal(t, value[0].score, 0)
 		}
 	})
+}
+
+func BenchmarkIgnore(b *testing.B) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		b.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	for i := 0; i < b.N; i++ {
+		value := new(struct {
+			Age    int `db:"age"`
+			Name   string
+			Ignore bool `db:"-"`
+		})
+
+		rs := sqlmock.NewRows([]string{"name", "age", "ignore"}).FromCSVString("liao,5,true")
+		mock.ExpectQuery("select (.+) from users where user=?").
+			WithArgs("anyone").WillReturnRows(rs)
+
+		assert.Nil(b, query(context.Background(), db, func(rows *sql.Rows) error {
+			return unmarshalRow(value, rows, true)
+		}, "select name, age from users where user=?", "anyone"))
+		assert.Equal(b, 5, value.Age)
+
+	}
 }
 
 type mockedScanner struct {

--- a/core/stores/sqlx/orm_test.go
+++ b/core/stores/sqlx/orm_test.go
@@ -370,6 +370,39 @@ func TestUnmarshalRowStructWithTags(t *testing.T) {
 	})
 }
 
+func TestUnmarshalRowStructWithTagsIgnoreFields(t *testing.T) {
+	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		value := new(struct {
+			Age    int `db:"age"`
+			Name   string
+			Ignore bool
+		})
+
+		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
+		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+
+		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
+			return unmarshalRow(value, rows, true)
+		}, "select name, age from users where user=?", "anyone"), ErrNotMatchDestination)
+	})
+
+	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		value := new(struct {
+			Age    int `db:"age"`
+			Name   string
+			Ignore bool `db:"-"`
+		})
+
+		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("liao,5")
+		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+
+		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
+			return unmarshalRow(value, rows, true)
+		}, "select name, age from users where user=?", "anyone"))
+		assert.Equal(t, 5, value.Age)
+	})
+}
+
 func TestUnmarshalRowStructWithTagsWrongColumns(t *testing.T) {
 	value := new(struct {
 		Age  *int   `db:"age"`
@@ -986,6 +1019,58 @@ func TestUnmarshalRowsStructWithTags(t *testing.T) {
 	}
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
+		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {
+			return unmarshalRows(&value, rows, true)
+		}, "select name, age from users where user=?", "anyone"))
+
+		for i, each := range expect {
+			assert.Equal(t, each.Name, value[i].Name)
+			assert.Equal(t, each.Age, value[i].Age)
+		}
+	})
+}
+
+func TestUnmarshalRowsStructWithTagsIgnoreFields(t *testing.T) {
+	expect := []struct {
+		Name   string
+		Age    int64
+		Ignore bool
+	}{
+		{
+			Name:   "first",
+			Age:    2,
+			Ignore: false,
+		},
+		{
+			Name:   "second",
+			Age:    3,
+			Ignore: false,
+		},
+	}
+
+	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		var value []struct {
+			Age    int64  `db:"age"`
+			Name   string `db:"name"`
+			Ignore bool
+		}
+
+		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
+		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
+		assert.ErrorIs(t, query(context.Background(), db, func(rows *sql.Rows) error {
+			return unmarshalRows(&value, rows, true)
+		}, "select name, age from users where user=?", "anyone"), ErrNotMatchDestination)
+	})
+
+	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		var value []struct {
+			Age    int64  `db:"age"`
+			Name   string `db:"name"`
+			Ignore bool   `db:"-"`
+		}
+
 		rs := sqlmock.NewRows([]string{"name", "age"}).FromCSVString("first,2\nsecond,3")
 		mock.ExpectQuery("select (.+) from users where user=?").WithArgs("anyone").WillReturnRows(rs)
 		assert.Nil(t, query(context.Background(), db, func(rows *sql.Rows) error {

--- a/core/stores/sqlx/rwstrategy.go
+++ b/core/stores/sqlx/rwstrategy.go
@@ -27,21 +27,21 @@ const (
 	notSpecifiedMode readWriteMode = ""
 )
 
-var readWriteModeKey struct{}
+type readWriteModeKey struct{}
 
 // WithReadPrimary sets the context to read-primary mode.
 func WithReadPrimary(ctx context.Context) context.Context {
-	return context.WithValue(ctx, readWriteModeKey, readPrimaryMode)
+	return context.WithValue(ctx, readWriteModeKey{}, readPrimaryMode)
 }
 
 // WithReadReplica sets the context to read-replica mode.
 func WithReadReplica(ctx context.Context) context.Context {
-	return context.WithValue(ctx, readWriteModeKey, readReplicaMode)
+	return context.WithValue(ctx, readWriteModeKey{}, readReplicaMode)
 }
 
 // WithWrite sets the context to write mode, indicating that the operation is a write operation.
 func WithWrite(ctx context.Context) context.Context {
-	return context.WithValue(ctx, readWriteModeKey, writeMode)
+	return context.WithValue(ctx, readWriteModeKey{}, writeMode)
 }
 
 type readWriteMode string
@@ -51,7 +51,7 @@ func (m readWriteMode) isValid() bool {
 }
 
 func getReadWriteMode(ctx context.Context) readWriteMode {
-	if mode := ctx.Value(readWriteModeKey); mode != nil {
+	if mode := ctx.Value(readWriteModeKey{}); mode != nil {
 		if v, ok := mode.(readWriteMode); ok && v.isValid() {
 			return v
 		}

--- a/core/stores/sqlx/rwstrategy.go
+++ b/core/stores/sqlx/rwstrategy.go
@@ -1,0 +1,65 @@
+package sqlx
+
+import "context"
+
+const (
+	// policyRoundRobin round-robin policy for selecting replicas.
+	policyRoundRobin = "round-robin"
+	// policyRandom random policy for selecting replicas.
+	policyRandom = "random"
+
+	// readPrimaryMode indicates that the operation is a read,
+	// but should be performed on the primary database instance.
+	//
+	// This mode is used in scenarios where data freshness and consistency are critical,
+	// such as immediately after writes or where replication lag may cause stale reads.
+	readPrimaryMode readWriteMode = "read-primary"
+
+	// readReplicaMode indicates that the operation is a read from replicas.
+	// This is suitable for scenarios where eventual consistency is acceptable,
+	// and the goal is to offload traffic from the primary and improve read scalability.
+	readReplicaMode readWriteMode = "read-replica"
+
+	// writeMode indicates that the operation is a write operation (to primary).
+	writeMode readWriteMode = "write"
+
+	// notSpecifiedMode indicates that the read/write mode is not specified.
+	notSpecifiedMode readWriteMode = ""
+)
+
+type readWriteMode string
+
+var readWriteModeKey struct{}
+
+func (m readWriteMode) isValid() bool {
+	return m == readPrimaryMode || m == readReplicaMode || m == writeMode
+}
+
+func getReadWriteMode(ctx context.Context) readWriteMode {
+	if mode := ctx.Value(readWriteModeKey); mode != nil {
+		if v, ok := mode.(readWriteMode); ok && v.isValid() {
+			return v
+		}
+	}
+
+	return notSpecifiedMode
+}
+
+func useReplica(ctx context.Context) bool {
+	return getReadWriteMode(ctx) == readReplicaMode
+}
+
+// WithReadPrimaryMode sets the context to read-primary mode.
+func WithReadPrimaryMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readWriteModeKey, readPrimaryMode)
+}
+
+// WithReadReplicaMode sets the context to read-replica mode.
+func WithReadReplicaMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readWriteModeKey, readReplicaMode)
+}
+
+// WithWriteMode sets the context to write mode, indicating that the operation is a write operation.
+func WithWriteMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readWriteModeKey, writeMode)
+}

--- a/core/stores/sqlx/rwstrategy.go
+++ b/core/stores/sqlx/rwstrategy.go
@@ -27,9 +27,24 @@ const (
 	notSpecifiedMode readWriteMode = ""
 )
 
-type readWriteMode string
-
 var readWriteModeKey struct{}
+
+// WithReadPrimary sets the context to read-primary mode.
+func WithReadPrimary(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readWriteModeKey, readPrimaryMode)
+}
+
+// WithReadReplica sets the context to read-replica mode.
+func WithReadReplica(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readWriteModeKey, readReplicaMode)
+}
+
+// WithWrite sets the context to write mode, indicating that the operation is a write operation.
+func WithWrite(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readWriteModeKey, writeMode)
+}
+
+type readWriteMode string
 
 func (m readWriteMode) isValid() bool {
 	return m == readPrimaryMode || m == readReplicaMode || m == writeMode
@@ -45,21 +60,6 @@ func getReadWriteMode(ctx context.Context) readWriteMode {
 	return notSpecifiedMode
 }
 
-func useReplica(ctx context.Context) bool {
-	return getReadWriteMode(ctx) == readReplicaMode
-}
-
-// WithReadPrimaryMode sets the context to read-primary mode.
-func WithReadPrimaryMode(ctx context.Context) context.Context {
-	return context.WithValue(ctx, readWriteModeKey, readPrimaryMode)
-}
-
-// WithReadReplicaMode sets the context to read-replica mode.
-func WithReadReplicaMode(ctx context.Context) context.Context {
-	return context.WithValue(ctx, readWriteModeKey, readReplicaMode)
-}
-
-// WithWriteMode sets the context to write mode, indicating that the operation is a write operation.
-func WithWriteMode(ctx context.Context) context.Context {
-	return context.WithValue(ctx, readWriteModeKey, writeMode)
+func usePrimary(ctx context.Context) bool {
+	return getReadWriteMode(ctx) != readReplicaMode
 }

--- a/core/stores/sqlx/rwstrategy_test.go
+++ b/core/stores/sqlx/rwstrategy_test.go
@@ -55,19 +55,19 @@ func TestIsValid(t *testing.T) {
 
 func TestWithReadMode(t *testing.T) {
 	ctx := context.Background()
-	readPrimaryCtx := WithReadPrimaryMode(ctx)
+	readPrimaryCtx := WithReadPrimary(ctx)
 
 	val := readPrimaryCtx.Value(readWriteModeKey)
 	assert.Equal(t, readPrimaryMode, val)
 
-	readReplicaCtx := WithReadReplicaMode(ctx)
+	readReplicaCtx := WithReadReplica(ctx)
 	val = readReplicaCtx.Value(readWriteModeKey)
 	assert.Equal(t, readReplicaMode, val)
 }
 
 func TestWithWriteMode(t *testing.T) {
 	ctx := context.Background()
-	writeCtx := WithWriteMode(ctx)
+	writeCtx := WithWrite(ctx)
 
 	val := writeCtx.Value(readWriteModeKey)
 	assert.Equal(t, writeMode, val)
@@ -105,29 +105,38 @@ func TestGetReadWriteMode(t *testing.T) {
 	})
 }
 
-func TestUuseReplica(t *testing.T) {
+func TestUsePrimary(t *testing.T) {
 	t.Run("context with read-replica mode", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), readWriteModeKey, readReplicaMode)
-		assert.True(t, useReplica(ctx))
+		assert.False(t, usePrimary(ctx))
 	})
 
 	t.Run("context with read-primary mode", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), readWriteModeKey, readPrimaryMode)
-		assert.False(t, useReplica(ctx))
+		assert.True(t, usePrimary(ctx))
 	})
 
 	t.Run("context with write mode", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), readWriteModeKey, writeMode)
-		assert.False(t, useReplica(ctx))
+		assert.True(t, usePrimary(ctx))
 	})
 
 	t.Run("context with invalid mode", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), readWriteModeKey, readWriteMode("invalid"))
-		assert.False(t, useReplica(ctx))
+		assert.True(t, usePrimary(ctx))
 	})
 
 	t.Run("context with no mode set", func(t *testing.T) {
 		ctx := context.Background()
-		assert.False(t, useReplica(ctx))
+		assert.True(t, usePrimary(ctx))
 	})
+}
+
+func TestWithModeTwice(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithReadPrimary(ctx)
+	writeCtx := WithWrite(ctx)
+
+	val := writeCtx.Value(readWriteModeKey)
+	assert.Equal(t, writeMode, val)
 }

--- a/core/stores/sqlx/rwstrategy_test.go
+++ b/core/stores/sqlx/rwstrategy_test.go
@@ -57,11 +57,11 @@ func TestWithReadMode(t *testing.T) {
 	ctx := context.Background()
 	readPrimaryCtx := WithReadPrimary(ctx)
 
-	val := readPrimaryCtx.Value(readWriteModeKey)
+	val := readPrimaryCtx.Value(readWriteModeKey{})
 	assert.Equal(t, readPrimaryMode, val)
 
 	readReplicaCtx := WithReadReplica(ctx)
-	val = readReplicaCtx.Value(readWriteModeKey)
+	val = readReplicaCtx.Value(readWriteModeKey{})
 	assert.Equal(t, readReplicaMode, val)
 }
 
@@ -69,33 +69,33 @@ func TestWithWriteMode(t *testing.T) {
 	ctx := context.Background()
 	writeCtx := WithWrite(ctx)
 
-	val := writeCtx.Value(readWriteModeKey)
+	val := writeCtx.Value(readWriteModeKey{})
 	assert.Equal(t, writeMode, val)
 }
 
 func TestGetReadWriteMode(t *testing.T) {
 	t.Run("valid read-primary mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, readPrimaryMode)
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, readPrimaryMode)
 		assert.Equal(t, readPrimaryMode, getReadWriteMode(ctx))
 	})
 
 	t.Run("valid read-replica mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, readReplicaMode)
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, readReplicaMode)
 		assert.Equal(t, readReplicaMode, getReadWriteMode(ctx))
 	})
 
 	t.Run("valid write mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, writeMode)
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, writeMode)
 		assert.Equal(t, writeMode, getReadWriteMode(ctx))
 	})
 
 	t.Run("invalid mode value (wrong type)", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, "not-a-mode")
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, "not-a-mode")
 		assert.Equal(t, notSpecifiedMode, getReadWriteMode(ctx))
 	})
 
 	t.Run("invalid mode value (wrong value)", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, readWriteMode("delete"))
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, readWriteMode("delete"))
 		assert.Equal(t, notSpecifiedMode, getReadWriteMode(ctx))
 	})
 
@@ -107,22 +107,22 @@ func TestGetReadWriteMode(t *testing.T) {
 
 func TestUsePrimary(t *testing.T) {
 	t.Run("context with read-replica mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, readReplicaMode)
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, readReplicaMode)
 		assert.False(t, usePrimary(ctx))
 	})
 
 	t.Run("context with read-primary mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, readPrimaryMode)
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, readPrimaryMode)
 		assert.True(t, usePrimary(ctx))
 	})
 
 	t.Run("context with write mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, writeMode)
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, writeMode)
 		assert.True(t, usePrimary(ctx))
 	})
 
 	t.Run("context with invalid mode", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), readWriteModeKey, readWriteMode("invalid"))
+		ctx := context.WithValue(context.Background(), readWriteModeKey{}, readWriteMode("invalid"))
 		assert.True(t, usePrimary(ctx))
 	})
 
@@ -137,6 +137,6 @@ func TestWithModeTwice(t *testing.T) {
 	ctx = WithReadPrimary(ctx)
 	writeCtx := WithWrite(ctx)
 
-	val := writeCtx.Value(readWriteModeKey)
+	val := writeCtx.Value(readWriteModeKey{})
 	assert.Equal(t, writeMode, val)
 }

--- a/core/stores/sqlx/rwstrategy_test.go
+++ b/core/stores/sqlx/rwstrategy_test.go
@@ -1,0 +1,133 @@
+package sqlx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValid(t *testing.T) {
+	testCases := []struct {
+		name     string
+		mode     readWriteMode
+		expected bool
+	}{
+		{
+			name:     "valid read-primary mode",
+			mode:     readPrimaryMode,
+			expected: true,
+		},
+		{
+			name:     "valid read-replica mode",
+			mode:     readReplicaMode,
+			expected: true,
+		},
+		{
+			name:     "valid write mode",
+			mode:     writeMode,
+			expected: true,
+		},
+		{
+			name:     "not specified mode (empty)",
+			mode:     notSpecifiedMode,
+			expected: false,
+		},
+		{
+			name:     "invalid custom string",
+			mode:     readWriteMode("delete"),
+			expected: false,
+		},
+		{
+			name:     "case sensitive check",
+			mode:     readWriteMode("READ"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.mode.isValid()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestWithReadMode(t *testing.T) {
+	ctx := context.Background()
+	readPrimaryCtx := WithReadPrimaryMode(ctx)
+
+	val := readPrimaryCtx.Value(readWriteModeKey)
+	assert.Equal(t, readPrimaryMode, val)
+
+	readReplicaCtx := WithReadReplicaMode(ctx)
+	val = readReplicaCtx.Value(readWriteModeKey)
+	assert.Equal(t, readReplicaMode, val)
+}
+
+func TestWithWriteMode(t *testing.T) {
+	ctx := context.Background()
+	writeCtx := WithWriteMode(ctx)
+
+	val := writeCtx.Value(readWriteModeKey)
+	assert.Equal(t, writeMode, val)
+}
+
+func TestGetReadWriteMode(t *testing.T) {
+	t.Run("valid read-primary mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, readPrimaryMode)
+		assert.Equal(t, readPrimaryMode, getReadWriteMode(ctx))
+	})
+
+	t.Run("valid read-replica mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, readReplicaMode)
+		assert.Equal(t, readReplicaMode, getReadWriteMode(ctx))
+	})
+
+	t.Run("valid write mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, writeMode)
+		assert.Equal(t, writeMode, getReadWriteMode(ctx))
+	})
+
+	t.Run("invalid mode value (wrong type)", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, "not-a-mode")
+		assert.Equal(t, notSpecifiedMode, getReadWriteMode(ctx))
+	})
+
+	t.Run("invalid mode value (wrong value)", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, readWriteMode("delete"))
+		assert.Equal(t, notSpecifiedMode, getReadWriteMode(ctx))
+	})
+
+	t.Run("no mode set", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Equal(t, notSpecifiedMode, getReadWriteMode(ctx))
+	})
+}
+
+func TestUuseReplica(t *testing.T) {
+	t.Run("context with read-replica mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, readReplicaMode)
+		assert.True(t, useReplica(ctx))
+	})
+
+	t.Run("context with read-primary mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, readPrimaryMode)
+		assert.False(t, useReplica(ctx))
+	})
+
+	t.Run("context with write mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, writeMode)
+		assert.False(t, useReplica(ctx))
+	})
+
+	t.Run("context with invalid mode", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), readWriteModeKey, readWriteMode("invalid"))
+		assert.False(t, useReplica(ctx))
+	})
+
+	t.Run("context with no mode set", func(t *testing.T) {
+		ctx := context.Background()
+		assert.False(t, useReplica(ctx))
+	})
+}

--- a/core/stores/sqlx/sqlconn.go
+++ b/core/stores/sqlx/sqlconn.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"math/rand"
+	"sync/atomic"
 
 	"github.com/zeromicro/go-zero/core/breaker"
 	"github.com/zeromicro/go-zero/core/errorx"
@@ -52,9 +55,10 @@ type (
 		beginTx  beginnable
 		brk      breaker.Breaker
 		accept   breaker.Acceptable
+		index    uint32
 	}
 
-	connProvider func() (*sql.DB, error)
+	connProvider func(ctx context.Context) (*sql.DB, error)
 
 	sessionConn interface {
 		Exec(query string, args ...any) (sql.Result, error)
@@ -64,10 +68,31 @@ type (
 	}
 )
 
+// NewConn returns a SqlConn with the given SqlConf.
+func NewConn(c SqlConf, opts ...SqlOption) SqlConn {
+	if err := c.Validate(); err != nil {
+		logx.Must(err)
+	}
+
+	conn := &commonSqlConn{
+		onError: func(ctx context.Context, err error) {
+			logInstanceError(ctx, c.DataSource, err)
+		},
+		beginTx: begin,
+		brk:     breaker.NewBreaker(),
+	}
+	for _, opt := range opts {
+		opt(conn)
+	}
+	conn.connProv = getConnProvider(conn, c.DriverName, c.DataSource, c.Policy, c.Replicas)
+
+	return conn
+}
+
 // NewSqlConn returns a SqlConn with given driver name and datasource.
 func NewSqlConn(driverName, datasource string, opts ...SqlOption) SqlConn {
 	conn := &commonSqlConn{
-		connProv: func() (*sql.DB, error) {
+		connProv: func(context.Context) (*sql.DB, error) {
 			return getSqlConn(driverName, datasource)
 		},
 		onError: func(ctx context.Context, err error) {
@@ -87,7 +112,7 @@ func NewSqlConn(driverName, datasource string, opts ...SqlOption) SqlConn {
 // Use it with caution; it's provided for other ORM to interact with.
 func NewSqlConnFromDB(db *sql.DB, opts ...SqlOption) SqlConn {
 	conn := &commonSqlConn{
-		connProv: func() (*sql.DB, error) {
+		connProv: func(ctx context.Context) (*sql.DB, error) {
 			return db, nil
 		},
 		onError: func(ctx context.Context, err error) {
@@ -123,7 +148,7 @@ func (db *commonSqlConn) ExecCtx(ctx context.Context, q string, args ...any) (
 
 	err = db.brk.DoWithAcceptableCtx(ctx, func() error {
 		var conn *sql.DB
-		conn, err = db.connProv()
+		conn, err = db.connProv(ctx)
 		if err != nil {
 			db.onError(ctx, err)
 			return err
@@ -151,7 +176,7 @@ func (db *commonSqlConn) PrepareCtx(ctx context.Context, query string) (stmt Stm
 
 	err = db.brk.DoWithAcceptableCtx(ctx, func() error {
 		var conn *sql.DB
-		conn, err = db.connProv()
+		conn, err = db.connProv(ctx)
 		if err != nil {
 			db.onError(ctx, err)
 			return err
@@ -242,7 +267,7 @@ func (db *commonSqlConn) QueryRowsPartialCtx(ctx context.Context, v any,
 }
 
 func (db *commonSqlConn) RawDB() (*sql.DB, error) {
-	return db.connProv()
+	return db.connProv(context.Background())
 }
 
 func (db *commonSqlConn) Transact(fn func(Session) error) error {
@@ -288,7 +313,7 @@ func (db *commonSqlConn) queryRows(ctx context.Context, scanner func(*sql.Rows) 
 	q string, args ...any) (err error) {
 	var scanFailed bool
 	err = db.brk.DoWithAcceptableCtx(ctx, func() error {
-		conn, err := db.connProv()
+		conn, err := db.connProv(ctx)
 		if err != nil {
 			db.onError(ctx, err)
 			return err
@@ -309,6 +334,38 @@ func (db *commonSqlConn) queryRows(ctx context.Context, scanner func(*sql.Rows) 
 	}
 
 	return
+}
+
+func getConnProvider(sc *commonSqlConn, driverName, datasource, policy string, replicas []string) connProvider {
+	return func(ctx context.Context) (*sql.DB, error) {
+		replicaCount := len(replicas)
+
+		if replicaCount == 0 || !useReplica(ctx) {
+			return getSqlConn(driverName, datasource)
+		}
+
+		var dsn string
+
+		if replicaCount == 1 {
+			dsn = replicas[0]
+		} else {
+			if len(policy) == 0 {
+				policy = policyRoundRobin
+			}
+
+			switch policy {
+			case policyRandom:
+				dsn = replicas[rand.Intn(replicaCount)]
+			case policyRoundRobin:
+				index := atomic.AddUint32(&sc.index, 1) - 1
+				dsn = replicas[index%uint32(replicaCount)]
+			default:
+				return nil, fmt.Errorf("unknown policy: %s", policy)
+			}
+		}
+
+		return getSqlConn(driverName, dsn)
+	}
 }
 
 // WithAcceptable returns a SqlOption that setting the acceptable function.

--- a/core/stores/sqlx/sqlconn_test.go
+++ b/core/stores/sqlx/sqlconn_test.go
@@ -1,6 +1,7 @@
 package sqlx
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"io"
@@ -98,7 +99,7 @@ func TestSqlConn_RawDB(t *testing.T) {
 func TestSqlConn_Errors(t *testing.T) {
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		conn := NewSqlConnFromDB(db)
-		conn.(*commonSqlConn).connProv = func() (*sql.DB, error) {
+		conn.(*commonSqlConn).connProv = func(ctx context.Context) (*sql.DB, error) {
 			return nil, errors.New("error")
 		}
 		_, err := conn.Prepare("any")
@@ -135,6 +136,148 @@ func TestSqlConn_Errors(t *testing.T) {
 		var vals []string
 		err := conn.QueryRows(&vals, "any")
 		assert.Equal(t, breaker.ErrServiceUnavailable, err)
+	})
+}
+
+func TestConfigSqlConn(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NotNil(t, db)
+	assert.NotNil(t, mock)
+	assert.Nil(t, err)
+	connManager.Inject(mockedDatasource, db)
+	mock.ExpectExec("any")
+	mock.ExpectQuery("any").WillReturnRows(sqlmock.NewRows([]string{"foo"}))
+
+	conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+	conn := NewConn(conf, withMysqlAcceptable())
+
+	_, err = conn.Exec("any", "value")
+	assert.NotNil(t, err)
+	_, err = conn.Prepare("any")
+	assert.NotNil(t, err)
+
+	var val string
+	assert.NotNil(t, conn.QueryRow(&val, "any"))
+	assert.NotNil(t, conn.QueryRowPartial(&val, "any"))
+	assert.NotNil(t, conn.QueryRows(&val, "any"))
+	assert.NotNil(t, conn.QueryRowsPartial(&val, "any"))
+}
+
+func TestConfigSqlConnStatement(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NotNil(t, db)
+	assert.NotNil(t, mock)
+	assert.Nil(t, err)
+	connManager.Inject(mockedDatasource, db)
+
+	mock.ExpectPrepare("any")
+	mock.ExpectExec("any").WillReturnResult(sqlmock.NewResult(2, 3))
+	mock.ExpectPrepare("any")
+	row := sqlmock.NewRows([]string{"foo"}).AddRow("bar")
+	mock.ExpectQuery("any").WillReturnRows(row)
+
+	conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+	conn := NewConn(conf, withMysqlAcceptable())
+	stmt, err := conn.Prepare("any")
+	assert.NoError(t, err)
+
+	res, err := stmt.Exec()
+	assert.NoError(t, err)
+	lastInsertID, err := res.LastInsertId()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), lastInsertID)
+	rowsAffected, err := res.RowsAffected()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), rowsAffected)
+
+	stmt, err = conn.Prepare("any")
+	assert.NoError(t, err)
+
+	var val string
+	err = stmt.QueryRow(&val)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", val)
+
+	mock.ExpectPrepare("any")
+	rows := sqlmock.NewRows([]string{"any"}).AddRow("foo").AddRow("bar")
+	mock.ExpectQuery("any").WillReturnRows(rows)
+
+	stmt, err = conn.Prepare("any")
+	assert.NoError(t, err)
+
+	var vals []string
+	assert.NoError(t, stmt.QueryRowsPartial(&vals))
+	assert.ElementsMatch(t, []string{"foo", "bar"}, vals)
+}
+
+func TestConfigSqlConnQuery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NotNil(t, db)
+	assert.NotNil(t, mock)
+	assert.Nil(t, err)
+	connManager.Inject(mockedDatasource, db)
+
+	t.Run("QueryRow", func(t *testing.T) {
+		mock.ExpectQuery("any").WillReturnRows(sqlmock.NewRows([]string{"foo"}).AddRow("bar"))
+		conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+		conn := NewConn(conf)
+		var val string
+		assert.NoError(t, conn.QueryRow(&val, "any"))
+		assert.Equal(t, "bar", val)
+	})
+
+	t.Run("QueryRowPartial", func(t *testing.T) {
+		mock.ExpectQuery("any").WillReturnRows(sqlmock.NewRows([]string{"foo"}).AddRow("bar"))
+		conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+		conn := NewConn(conf)
+		var val string
+		assert.NoError(t, conn.QueryRowPartial(&val, "any"))
+		assert.Equal(t, "bar", val)
+	})
+
+	t.Run("QueryRows", func(t *testing.T) {
+		mock.ExpectQuery("any").WillReturnRows(sqlmock.NewRows([]string{"any"}).AddRow("foo").AddRow("bar"))
+		conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+		conn := NewConn(conf)
+		var vals []string
+		assert.NoError(t, conn.QueryRows(&vals, "any"))
+		assert.ElementsMatch(t, []string{"foo", "bar"}, vals)
+	})
+
+	t.Run("QueryRowsPartial", func(t *testing.T) {
+		mock.ExpectQuery("any").WillReturnRows(sqlmock.NewRows([]string{"any"}).AddRow("foo").AddRow("bar"))
+		conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+		conn := NewConn(conf)
+		var vals []string
+		assert.NoError(t, conn.QueryRowsPartial(&vals, "any"))
+		assert.ElementsMatch(t, []string{"foo", "bar"}, vals)
+	})
+}
+
+func TestConfigSqlConnErr(t *testing.T) {
+	t.Run("panic on empty config", func(t *testing.T) {
+		original := logx.ExitOnFatal.True()
+		logx.ExitOnFatal.Set(false)
+		defer logx.ExitOnFatal.Set(original)
+
+		assert.Panics(t, func() {
+			NewConn(SqlConf{})
+		})
+	})
+	t.Run("on error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		assert.NotNil(t, db)
+		assert.NotNil(t, mock)
+		assert.Nil(t, err)
+		connManager.Inject(mockedDatasource, db)
+
+		conf := SqlConf{DataSource: mockedDatasource, DriverName: mysqlDriverName}
+		conn := NewConn(conf)
+		conn.(*commonSqlConn).connProv = func(ctx context.Context) (*sql.DB, error) {
+			return nil, errors.New("error")
+		}
+		_, err = conn.Prepare("any")
+		assert.Error(t, err)
 	})
 }
 
@@ -301,6 +444,93 @@ func TestWithAcceptable(t *testing.T) {
 	assert.True(t, conn.accept(acceptableErr))
 	assert.True(t, conn.accept(acceptableErr2))
 	assert.True(t, conn.accept(acceptableErr3))
+}
+
+func TestProvider(t *testing.T) {
+	defer func() {
+		_ = connManager.Close()
+	}()
+
+	primaryDSN := "primary:password@tcp(127.0.0.1:3306)/primary_db"
+	replicasDSN := []string{
+		"replica_one:pwd@tcp(localhost:3306)/replica_one",
+		"replica_two:pwd@tcp(localhost:3306)/replica_two",
+		"replica_three:pwd@tcp(localhost:3306)/replica_three",
+	}
+
+	primaryDB, err := connManager.GetResource(primaryDSN, func() (io.Closer, error) { return sql.Open(mysqlDriverName, primaryDSN) })
+	assert.Nil(t, err)
+	assert.NotNil(t, primaryDB)
+	replicaOneDB, err := connManager.GetResource(replicasDSN[0], func() (io.Closer, error) { return sql.Open(mysqlDriverName, replicasDSN[0]) })
+	assert.Nil(t, err)
+	assert.NotNil(t, replicaOneDB)
+	replicaTwoDB, err := connManager.GetResource(replicasDSN[1], func() (io.Closer, error) { return sql.Open(mysqlDriverName, replicasDSN[1]) })
+	assert.Nil(t, err)
+	assert.NotNil(t, replicaTwoDB)
+	replicaThreeDB, err := connManager.GetResource(replicasDSN[2], func() (io.Closer, error) { return sql.Open(mysqlDriverName, replicasDSN[2]) })
+	assert.Nil(t, err)
+	assert.NotNil(t, replicaThreeDB)
+
+	sc := &commonSqlConn{}
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, policyRoundRobin, nil)
+
+	ctx := context.Background()
+	db, err := sc.connProv(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, primaryDB, db)
+
+	ctx = WithWriteMode(ctx)
+	db, err = sc.connProv(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, primaryDB, db)
+
+	ctx = WithReadPrimaryMode(ctx)
+	db, err = sc.connProv(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, primaryDB, db)
+
+	// no mode set, should return primary
+	ctx = context.Background()
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, policyRoundRobin, replicasDSN)
+	db, err = sc.connProv(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, primaryDB, db)
+
+	ctx = WithReadReplicaMode(ctx)
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, policyRoundRobin, []string{replicasDSN[0]})
+	db, err = sc.connProv(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, replicaOneDB, db)
+
+	// default policy is round-robin
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, policyRoundRobin, replicasDSN)
+	replicas := []io.Closer{replicaOneDB, replicaTwoDB, replicaThreeDB}
+	for i := 0; i < len(replicasDSN); i++ {
+		db, err = sc.connProv(ctx)
+		assert.Nil(t, err)
+		assert.Equal(t, replicas[i], db)
+	}
+
+	// random policy
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, policyRandom, replicasDSN)
+	for i := 0; i < len(replicasDSN); i++ {
+		db, err = sc.connProv(ctx)
+		assert.Nil(t, err)
+		assert.Contains(t, replicas, db)
+	}
+
+	// unknown policy
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, "unknown", replicasDSN)
+	_, err = sc.connProv(ctx)
+	assert.NotNil(t, err)
+
+	// empty policy transforms to round-robin
+	sc.connProv = getConnProvider(sc, mysqlDriverName, primaryDSN, "", replicasDSN)
+	for i := 0; i < len(replicasDSN); i++ {
+		db, err = sc.connProv(ctx)
+		assert.Nil(t, err)
+		assert.Equal(t, replicas[i], db)
+	}
 }
 
 func buildConn() (mock sqlmock.Sqlmock, err error) {

--- a/core/stores/sqlx/tx.go
+++ b/core/stores/sqlx/tx.go
@@ -156,7 +156,7 @@ func begin(db *sql.DB) (trans, error) {
 
 func transact(ctx context.Context, db *commonSqlConn, b beginnable,
 	fn func(context.Context, Session) error) (err error) {
-	conn, err := db.connProv()
+	conn, err := db.connProv(ctx)
 	if err != nil {
 		db.onError(ctx, err)
 		return err

--- a/core/stores/sqlx/tx_test.go
+++ b/core/stores/sqlx/tx_test.go
@@ -117,7 +117,7 @@ func TestTxExceptions(t *testing.T) {
 
 	dbtest.RunTest(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		conn := &commonSqlConn{
-			connProv: func() (*sql.DB, error) {
+			connProv: func(ctx context.Context) (*sql.DB, error) {
 				return nil, errors.New("foo")
 			},
 			beginTx: begin,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/grafana/pyroscope-go v1.2.2
+	github.com/grafana/pyroscope-go v1.2.3
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jhump/protoreflect v1.17.0
 	github.com/pelletier/go-toml/v2 v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/grafana/pyroscope-go v1.2.3
+	github.com/grafana/pyroscope-go v1.2.4
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jhump/protoreflect v1.17.0
 	github.com/pelletier/go-toml/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/pyroscope-go v1.2.3 h1:Rp8mjqqGqmRDvV6XYmuedUAv7wVnQJK/M1pBt6uNwxU=
-github.com/grafana/pyroscope-go v1.2.3/go.mod h1:zzT9QXQAp2Iz2ZdS216UiV8y9uXJYQiGE1q8v1FyhqU=
+github.com/grafana/pyroscope-go v1.2.4 h1:B22GMXz+O0nWLatxLuaP7o7L9dvP0clLvIpmeEQQM0Q=
+github.com/grafana/pyroscope-go v1.2.4/go.mod h1:zzT9QXQAp2Iz2ZdS216UiV8y9uXJYQiGE1q8v1FyhqU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/pyroscope-go v1.2.2 h1:uvKCyZMD724RkaCEMrSTC38Yn7AnFe8S2wiAIYdDPCE=
-github.com/grafana/pyroscope-go v1.2.2/go.mod h1:zzT9QXQAp2Iz2ZdS216UiV8y9uXJYQiGE1q8v1FyhqU=
+github.com/grafana/pyroscope-go v1.2.3 h1:Rp8mjqqGqmRDvV6XYmuedUAv7wVnQJK/M1pBt6uNwxU=
+github.com/grafana/pyroscope-go v1.2.3/go.mod h1:zzT9QXQAp2Iz2ZdS216UiV8y9uXJYQiGE1q8v1FyhqU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=

--- a/rest/engine.go
+++ b/rest/engine.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/zeromicro/go-zero/core/codec"
 	"github.com/zeromicro/go-zero/core/load"
+	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stat"
 	"github.com/zeromicro/go-zero/rest/chain"
 	"github.com/zeromicro/go-zero/rest/handler"
@@ -70,6 +71,11 @@ func buildSSERoutes(routes []Route) []Route {
 	for i, route := range routes {
 		h := route.Handler
 		routes[i].Handler = func(w http.ResponseWriter, r *http.Request) {
+			rc := http.NewResponseController(w)
+			err := rc.SetWriteDeadline(time.Time{})
+			if err != nil {
+				logx.Errorf("set conn write deadline failed:%v", err)
+			}
 			w.Header().Set(header.ContentType, header.ContentTypeEventStream)
 			w.Header().Set(header.CacheControl, header.CacheControlNoCache)
 			w.Header().Set(header.Connection, header.ConnectionKeepAlive)

--- a/rest/engine_test.go
+++ b/rest/engine_test.go
@@ -578,3 +578,7 @@ func (m mockedRouter) SetNotFoundHandler(_ http.Handler) {
 
 func (m mockedRouter) SetNotAllowedHandler(_ http.Handler) {
 }
+
+func ptrOfDuration(d time.Duration) *time.Duration {
+	return &d
+}

--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/zeromicro/go-zero/core/color"
@@ -24,12 +25,12 @@ import (
 )
 
 const (
-	limitBodyBytes         = 1024
-	limitDetailedBodyBytes = 4096
-	defaultSlowThreshold   = time.Millisecond * 500
+	limitBodyBytes       = 1024
+	defaultSlowThreshold = time.Millisecond * 500
 )
 
 var slowThreshold = syncx.ForAtomicDuration(defaultSlowThreshold)
+var limitDetailedBodyBytes atomic.Uint32
 
 // LogHandler returns a middleware that logs http request and response.
 func LogHandler(next http.Handler) http.Handler {
@@ -96,7 +97,12 @@ func DetailedLogHandler(next http.Handler) http.Handler {
 
 		var dup io.ReadCloser
 		// https://github.com/zeromicro/go-zero/issues/3564
-		r.Body, dup = iox.LimitDupReadCloser(r.Body, limitDetailedBodyBytes)
+		if limitDetailedBodyBytes.Load() == 0 {
+			// The maximum length is not set or zero. Print the complete body to the log.
+			r.Body, dup = iox.DupReadCloser(r.Body)
+		} else {
+			r.Body, dup = iox.LimitDupReadCloser(r.Body, int64(limitDetailedBodyBytes.Load()))
+		}
 		logs := new(internal.LogCollector)
 		next.ServeHTTP(lrw, r.WithContext(internal.WithLogCollector(r.Context(), logs)))
 		r.Body = dup
@@ -107,6 +113,11 @@ func DetailedLogHandler(next http.Handler) http.Handler {
 // SetSlowThreshold sets the slow threshold.
 func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
+}
+
+// SetLimitDetailedBodyBytes Set the maximum length of the body contained in the log
+func SetLimitDetailedBodyBytes(limit uint32) {
+	limitDetailedBodyBytes.Store(limit)
 }
 
 func dumpRequest(r *http.Request) string {

--- a/rest/handler/loghandler_test.go
+++ b/rest/handler/loghandler_test.go
@@ -91,20 +91,45 @@ func TestLogHandlerSlow(t *testing.T) {
 func TestDetailedLogHandler_LargeBody(t *testing.T) {
 	lbuf := logtest.NewCollector(t)
 
+	const limit uint32 = 1024
+	SetLimitDetailedBodyBytes(limit)
+
 	var buf bytes.Buffer
-	for i := 0; i < limitDetailedBodyBytes<<2; i++ {
+	for i := 0; i < int(limitDetailedBodyBytes.Load())<<2; i++ {
 		buf.WriteByte('a')
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "http://localhost", &buf)
 	h := DetailedLogHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		io.Copy(io.Discard, r.Body)
+		_, _ = io.Copy(io.Discard, r.Body)
 	}))
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
 
 	// extra 200 for the length of POST request headers
-	assert.True(t, len(lbuf.Content()) < limitDetailedBodyBytes+200)
+	assert.True(t, len(lbuf.Content()) < int(limit)+200)
+}
+
+func TestDetailedLogHandler_LargeBody_NoLimit(t *testing.T) {
+	lbuf := logtest.NewCollector(t)
+
+	// No limit
+	SetLimitDetailedBodyBytes(0)
+	const bodyContentLength = 2048
+	var buf bytes.Buffer
+	for i := 0; i < bodyContentLength; i++ {
+		buf.WriteByte('a')
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost", &buf)
+	h := DetailedLogHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+	}))
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	// No limit, log length is greater than the passed-in body length.
+	assert.True(t, len(lbuf.Content()) > bodyContentLength)
 }
 
 func TestDetailedLogHandler_Hijack(t *testing.T) {

--- a/rest/handler/tracehandler.go
+++ b/rest/handler/tracehandler.go
@@ -29,8 +29,8 @@ func TraceHandler(serviceName, path string, opts ...TraceOption) func(http.Handl
 		opt(&options)
 	}
 
-	ignorePaths := collection.NewSet()
-	ignorePaths.AddStr(options.traceIgnorePaths...)
+	ignorePaths := collection.NewSet[string]()
+	ignorePaths.Add(options.traceIgnorePaths...)
 
 	return func(next http.Handler) http.Handler {
 		tracer := otel.Tracer(trace.TraceName)

--- a/rest/internal/response/withcoderesponsewriter.go
+++ b/rest/internal/response/withcoderesponsewriter.go
@@ -59,3 +59,8 @@ func (w *WithCodeResponseWriter) WriteHeader(code int) {
 	w.Writer.WriteHeader(code)
 	w.Code = code
 }
+
+// Unwrap returns the underlying ResponseWriter.
+func (w *WithCodeResponseWriter) Unwrap() http.ResponseWriter {
+	return w.Writer
+}

--- a/rest/internal/response/withcoderesponsewriter.go
+++ b/rest/internal/response/withcoderesponsewriter.go
@@ -49,6 +49,12 @@ func (w *WithCodeResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, errors.New("server doesn't support hijacking")
 }
 
+// Unwrap returns the underlying http.ResponseWriter.
+// This is used by http.ResponseController to unwrap the response writer.
+func (w *WithCodeResponseWriter) Unwrap() http.ResponseWriter {
+	return w.Writer
+}
+
 // Write writes bytes into w.
 func (w *WithCodeResponseWriter) Write(bytes []byte) (int, error) {
 	return w.Writer.Write(bytes)
@@ -58,9 +64,4 @@ func (w *WithCodeResponseWriter) Write(bytes []byte) (int, error) {
 func (w *WithCodeResponseWriter) WriteHeader(code int) {
 	w.Writer.WriteHeader(code)
 	w.Code = code
-}
-
-// Unwrap returns the underlying ResponseWriter.
-func (w *WithCodeResponseWriter) Unwrap() http.ResponseWriter {
-	return w.Writer
 }

--- a/rest/internal/response/withcoderesponsewriter_test.go
+++ b/rest/internal/response/withcoderesponsewriter_test.go
@@ -46,3 +46,15 @@ func TestWithCodeResponseWriter_Hijack(t *testing.T) {
 		writer.Hijack()
 	})
 }
+
+func TestWithCodeResponseWriter_Unwrap(t *testing.T) {
+	resp := httptest.NewRecorder()
+	writer := NewWithCodeResponseWriter(resp)
+	unwrapped := writer.Unwrap()
+	assert.Equal(t, resp, unwrapped)
+
+	// Test with a nested WithCodeResponseWriter
+	nestedWriter := NewWithCodeResponseWriter(writer)
+	unwrappedNested := nestedWriter.Unwrap()
+	assert.Equal(t, resp, unwrappedNested)
+}

--- a/rest/server.go
+++ b/rest/server.go
@@ -119,6 +119,16 @@ func (s *Server) Use(middleware Middleware) {
 	s.ngin.use(middleware)
 }
 
+// build builds the Server and binds the routes to the router.
+func (s *Server) build() error {
+	return s.ngin.bindRoutes(s.router)
+}
+
+// serve serves the HTTP requests using the Server's router.
+func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
+	s.router.ServeHTTP(w, r)
+}
+
 // ToMiddleware converts the given handler to a Middleware.
 func ToMiddleware(handler func(next http.Handler) http.Handler) Middleware {
 	return func(handle http.HandlerFunc) http.HandlerFunc {

--- a/rest/server.go
+++ b/rest/server.go
@@ -293,7 +293,6 @@ func WithSignature(signature SignatureConf) RouteOption {
 func WithSSE() RouteOption {
 	return func(r *featuredRoutes) {
 		r.sse = true
-		r.timeout = ptrOfDuration(0)
 	}
 }
 
@@ -333,10 +332,6 @@ func handleError(err error) {
 
 	logx.Error(err)
 	panic(err)
-}
-
-func ptrOfDuration(d time.Duration) *time.Duration {
-	return &d
 }
 
 func validateSecret(secret string) {

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -819,6 +819,6 @@ func TestServerEmbedFileSystem(t *testing.T) {
 //	serve(server, w, r)
 //	// verify the response
 func serve(s *Server, w http.ResponseWriter, r *http.Request) {
-	s.ngin.bindRoutes(s.router)
-	s.router.ServeHTTP(w, r)
+	_ = s.build()
+	s.serve(w, r)
 }

--- a/rest/serverless.go
+++ b/rest/serverless.go
@@ -1,0 +1,27 @@
+package rest
+
+import "net/http"
+
+// Serverless is a wrapper around Server that allows it to be used in serverless environments.
+type Serverless struct {
+	server *Server
+}
+
+// NewServerless creates a new Serverless instance from the provided Server.
+func NewServerless(server *Server) (*Serverless, error) {
+	// Ensure the server is built before using it in a serverless context.
+	// Why not call server.build() when serving requests,
+	// is because we need to ensure fail fast behavior.
+	if err := server.build(); err != nil {
+		return nil, err
+	}
+
+	return &Serverless{
+		server: server,
+	}, nil
+}
+
+// Serve handles HTTP requests by delegating them to the underlying Server instance.
+func (s *Serverless) Serve(w http.ResponseWriter, r *http.Request) {
+	s.server.serve(w, r)
+}

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -1,0 +1,67 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeromicro/go-zero/core/conf"
+	"github.com/zeromicro/go-zero/core/logx/logtest"
+)
+
+func TestNewServerless(t *testing.T) {
+	logtest.Discard(t)
+
+	const configYaml = `
+Name: foo
+Host: localhost
+Port: 0
+`
+	var cnf RestConf
+	assert.Nil(t, conf.LoadFromYamlBytes([]byte(configYaml), &cnf))
+
+	svr, err := NewServer(cnf)
+	assert.NoError(t, err)
+
+	svr.AddRoute(Route{
+		Method: http.MethodGet,
+		Path:   "/",
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("Hello World"))
+		},
+	})
+
+	serverless, err := NewServerless(svr)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	serverless.Serve(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Hello World", w.Body.String())
+}
+
+func TestNewServerlessWithError(t *testing.T) {
+	logtest.Discard(t)
+
+	const configYaml = `
+Name: foo
+Host: localhost
+Port: 0
+`
+	var cnf RestConf
+	assert.Nil(t, conf.LoadFromYamlBytes([]byte(configYaml), &cnf))
+
+	svr, err := NewServer(cnf)
+	assert.NoError(t, err)
+
+	svr.AddRoute(Route{
+		Method:  http.MethodGet,
+		Path:    "notstartwith/",
+		Handler: nil,
+	})
+
+	_, err = NewServerless(svr)
+	assert.Error(t, err)
+}

--- a/tools/goctl/api/swagger/parameter.go
+++ b/tools/goctl/api/swagger/parameter.go
@@ -9,7 +9,7 @@ import (
 )
 
 func isPostJson(ctx Context, method string, tp apiSpec.Type) (string, bool) {
-	if strings.EqualFold(method, http.MethodPost) {
+	if !strings.EqualFold(method, http.MethodPost) {
 		return "", false
 	}
 	structType, ok := tp.(apiSpec.DefineStruct)

--- a/tools/goctl/api/swagger/parameter_test.go
+++ b/tools/goctl/api/swagger/parameter_test.go
@@ -1,0 +1,91 @@
+package swagger
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiSpec "github.com/zeromicro/go-zero/tools/goctl/api/spec"
+)
+
+func TestIsPostJson(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		hasJson  bool
+		expected bool
+	}{
+		{"POST with JSON", http.MethodPost, true, true},
+		{"POST without JSON", http.MethodPost, false, false},
+		{"GET with JSON", http.MethodGet, true, false},
+		{"PUT with JSON", http.MethodPut, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testStruct := createTestStruct("TestStruct", tt.hasJson)
+			_, result := isPostJson(testingContext(t), tt.method, testStruct)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParametersFromType(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		useDefinitions bool
+		hasJson        bool
+		expectedCount  int
+		expectedBody   bool
+	}{
+		{"POST JSON with definitions", http.MethodPost, true, true, 1, true},
+		{"POST JSON without definitions", http.MethodPost, false, true, 1, true},
+		{"GET with form", http.MethodGet, false, false, 1, false},
+		{"POST with form", http.MethodPost, false, false, 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := Context{UseDefinitions: tt.useDefinitions}
+			testStruct := createTestStruct("TestStruct", tt.hasJson)
+			params := parametersFromType(ctx, tt.method, testStruct)
+
+			assert.Equal(t, tt.expectedCount, len(params))
+			if tt.expectedBody {
+				assert.Equal(t, paramsInBody, params[0].In)
+			} else if len(params) > 0 {
+				assert.NotEqual(t, paramsInBody, params[0].In)
+			}
+		})
+	}
+}
+
+func TestParametersFromType_EdgeCases(t *testing.T) {
+	ctx := testingContext(t)
+
+	params := parametersFromType(ctx, http.MethodPost, nil)
+	assert.Empty(t, params)
+
+	primitiveType := apiSpec.PrimitiveType{RawName: "string"}
+	params = parametersFromType(ctx, http.MethodPost, primitiveType)
+	assert.Empty(t, params)
+}
+
+func createTestStruct(name string, hasJson bool) apiSpec.DefineStruct {
+	tag := `form:"username"`
+	if hasJson {
+		tag = `json:"username"`
+	}
+
+	return apiSpec.DefineStruct{
+		RawName: name,
+		Members: []apiSpec.Member{
+			{
+				Name: "Username",
+				Type: apiSpec.PrimitiveType{RawName: "string"},
+				Tag:  tag,
+			},
+		},
+	}
+}

--- a/tools/goctl/config/default.yaml
+++ b/tools/goctl/config/default.yaml
@@ -10,6 +10,9 @@ model:
     decimal:
       null_type: sql.NullFloat64
       type: float64
+    numeric:
+      null_type: sql.NullFloat64
+      type: float64
     double:
       null_type: sql.NullFloat64
       type: float64

--- a/tools/goctl/go.mod
+++ b/tools/goctl/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	github.com/zeromicro/antlr v0.0.1
 	github.com/zeromicro/ddl-parser v1.0.5
-	github.com/zeromicro/go-zero v1.8.4
+	github.com/zeromicro/go-zero v1.8.5
 	golang.org/x/text v0.22.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.36.5
@@ -73,7 +73,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/redis/go-redis/v9 v9.10.0 // indirect
+	github.com/redis/go-redis/v9 v9.11.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect

--- a/tools/goctl/go.mod
+++ b/tools/goctl/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gookit/color v1.5.4
 	github.com/iancoleman/strcase v0.3.0
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
+	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.10.0
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	github.com/zeromicro/antlr v0.0.1

--- a/tools/goctl/go.sum
+++ b/tools/goctl/go.sum
@@ -148,8 +148,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/redis/go-redis/v9 v9.10.0 h1:FxwK3eV8p/CQa0Ch276C7u2d0eNC9kCmAYQ7mCXCzVs=
-github.com/redis/go-redis/v9 v9.10.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -185,8 +185,8 @@ github.com/zeromicro/antlr v0.0.1 h1:CQpIn/dc0pUjgGQ81y98s/NGOm2Hfru2NNio2I9mQgk
 github.com/zeromicro/antlr v0.0.1/go.mod h1:nfpjEwFR6Q4xGDJMcZnCL9tEfQRgszMwu3rDz2Z+p5M=
 github.com/zeromicro/ddl-parser v1.0.5 h1:LaVqHdzMTjasua1yYpIYaksxKqRzFrEukj2Wi2EbWaQ=
 github.com/zeromicro/ddl-parser v1.0.5/go.mod h1:ISU/8NuPyEpl9pa17Py9TBPetMjtsiHrb9f5XGiYbo8=
-github.com/zeromicro/go-zero v1.8.4 h1:3s7kOoThCnkDoqCafsqSX58Y9osYTBIa5QEmomw07TE=
-github.com/zeromicro/go-zero v1.8.4/go.mod h1:eM5f6If/RF+jG1wSCmlvfXD2h2l23vJwETI8oDpjYt4=
+github.com/zeromicro/go-zero v1.8.5 h1:YkdQhYllE+BPOrxcni0oCewebs7qHfXvjN9glnpcmJQ=
+github.com/zeromicro/go-zero v1.8.5/go.mod h1:P0DKW1vJx+2J3TReptbeg0H9tRSvehymr0HX4SCfZ6g=
 go.etcd.io/etcd/api/v3 v3.5.15 h1:3KpLJir1ZEBrYuV2v+Twaa/e2MdDCEZ/70H+lzEiwsk=
 go.etcd.io/etcd/api/v3 v3.5.15/go.mod h1:N9EhGzXq58WuMllgH9ZvnEr7SI9pS0k0+DHZezGp7jM=
 go.etcd.io/etcd/client/pkg/v3 v3.5.15 h1:fo0HpWz/KlHGMCC+YejpiCmyWDEuIpnTDzpJLB5fWlA=

--- a/tools/goctl/go.sum
+++ b/tools/goctl/go.sum
@@ -157,8 +157,9 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
+github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/tools/goctl/internal/version/version.go
+++ b/tools/goctl/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // BuildVersion is the version of goctl.
-const BuildVersion = "1.8.4"
+const BuildVersion = "1.8.5"
 
 var tag = map[string]int{"pre-alpha": 0, "alpha": 1, "pre-bata": 2, "beta": 3, "released": 4, "": 5}
 

--- a/tools/goctl/model/sql/model/postgresqlmodel.go
+++ b/tools/goctl/model/sql/model/postgresqlmodel.go
@@ -9,8 +9,6 @@ import (
 
 var p2m = map[string]string{
 	"int8":        "bigint",
-	"numeric":     "double",
-	"decimal":     "double",
 	"float8":      "double",
 	"float4":      "float",
 	"int2":        "smallint",

--- a/zrpc/internal/serverinterceptors/statinterceptor.go
+++ b/zrpc/internal/serverinterceptors/statinterceptor.go
@@ -43,8 +43,8 @@ func SetSlowThreshold(threshold time.Duration) {
 
 // UnaryStatInterceptor returns a func that uses given metrics to report stats.
 func UnaryStatInterceptor(metrics *stat.Metrics, conf StatConf) grpc.UnaryServerInterceptor {
-	staticNotLoggingContentMethods := collection.NewSet()
-	staticNotLoggingContentMethods.AddStr(conf.IgnoreContentMethods...)
+	staticNotLoggingContentMethods := collection.NewSet[string]()
+	staticNotLoggingContentMethods.Add(conf.IgnoreContentMethods...)
 
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler) (resp any, err error) {
@@ -68,7 +68,7 @@ func isSlow(duration, durationThreshold time.Duration) bool {
 }
 
 func logDuration(ctx context.Context, method string, req any, duration time.Duration,
-	ignoreMethods *collection.Set, durationThreshold time.Duration) {
+	ignoreMethods *collection.Set[string], durationThreshold time.Duration) {
 	var addr string
 	client, ok := peer.FromContext(ctx)
 	if ok {
@@ -92,7 +92,7 @@ func logDuration(ctx context.Context, method string, req any, duration time.Dura
 	}
 }
 
-func shouldLogContent(method string, ignoreMethods *collection.Set) bool {
+func shouldLogContent(method string, ignoreMethods *collection.Set[string]) bool {
 	_, ok := ignoreContentMethods.Load(method)
 	return !ok && !ignoreMethods.Contains(method)
 }

--- a/zrpc/internal/serverinterceptors/statinterceptor_test.go
+++ b/zrpc/internal/serverinterceptors/statinterceptor_test.go
@@ -88,7 +88,7 @@ func TestLogDuration(t *testing.T) {
 
 			assert.NotPanics(t, func() {
 				logDuration(test.ctx, "foo", test.req, test.duration,
-					collection.NewSet(), test.durationThreshold)
+					collection.NewSet[string](), test.durationThreshold)
 			})
 		})
 	}
@@ -150,7 +150,7 @@ func TestLogDurationWithoutContent(t *testing.T) {
 
 			assert.NotPanics(t, func() {
 				logDuration(test.ctx, "foo", test.req, test.duration,
-					collection.NewSet(), test.durationThreshold)
+					collection.NewSet[string](), test.durationThreshold)
 			})
 		})
 	}
@@ -206,9 +206,10 @@ func Test_shouldLogContent(t *testing.T) {
 			t.Cleanup(func() {
 				ignoreContentMethods = sync.Map{}
 			})
-			set := collection.NewSet()
-			set.AddStr(tt.args.staticNotLoggingContentMethods...)
-			assert.Equalf(t, tt.want, shouldLogContent(tt.args.method, set), "shouldLogContent(%v, %v)", tt.args.method, tt.args.staticNotLoggingContentMethods)
+			set := collection.NewSet[string]()
+			set.Add(tt.args.staticNotLoggingContentMethods...)
+			assert.Equalf(t, tt.want, shouldLogContent(tt.args.method, set),
+				"shouldLogContent(%v, %v)", tt.args.method, tt.args.staticNotLoggingContentMethods)
 		})
 	}
 }


### PR DESCRIPTION
Change the limit to a variable, support external settings, and do not limit by default to prevent break change.