### PR TITLE
feat: Add SetLimitDetailedBodyBytes method to restrict log writing.

### DIFF
--- a/rest/handler/loghandler.go
+++ b/rest/handler/loghandler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/zeromicro/go-zero/core/color"
@@ -24,12 +25,12 @@ import (
 )
 
 const (
-	limitBodyBytes         = 1024
-	limitDetailedBodyBytes = 4096
-	defaultSlowThreshold   = time.Millisecond * 500
+	limitBodyBytes       = 1024
+	defaultSlowThreshold = time.Millisecond * 500
 )
 
 var slowThreshold = syncx.ForAtomicDuration(defaultSlowThreshold)
+var limitDetailedBodyBytes atomic.Uint32
 
 // LogHandler returns a middleware that logs http request and response.
 func LogHandler(next http.Handler) http.Handler {
@@ -96,7 +97,12 @@ func DetailedLogHandler(next http.Handler) http.Handler {
 
 		var dup io.ReadCloser
 		// https://github.com/zeromicro/go-zero/issues/3564
-		r.Body, dup = iox.LimitDupReadCloser(r.Body, limitDetailedBodyBytes)
+		if limitDetailedBodyBytes.Load() == 0 {
+			// The maximum length is not set or zero. Print the complete body to the log.
+			r.Body, dup = iox.DupReadCloser(r.Body)
+		} else {
+			r.Body, dup = iox.LimitDupReadCloser(r.Body, int64(limitDetailedBodyBytes.Load()))
+		}
 		logs := new(internal.LogCollector)
 		next.ServeHTTP(lrw, r.WithContext(internal.WithLogCollector(r.Context(), logs)))
 		r.Body = dup
@@ -107,6 +113,11 @@ func DetailedLogHandler(next http.Handler) http.Handler {
 // SetSlowThreshold sets the slow threshold.
 func SetSlowThreshold(threshold time.Duration) {
 	slowThreshold.Set(threshold)
+}
+
+// SetLimitDetailedBodyBytes Set the maximum length of the body contained in the log
+func SetLimitDetailedBodyBytes(limit uint32) {
+	limitDetailedBodyBytes.Store(limit)
 }
 
 func dumpRequest(r *http.Request) string {

--- a/rest/handler/loghandler_test.go
+++ b/rest/handler/loghandler_test.go
@@ -91,20 +91,45 @@ func TestLogHandlerSlow(t *testing.T) {
 func TestDetailedLogHandler_LargeBody(t *testing.T) {
 	lbuf := logtest.NewCollector(t)
 
+	const limit uint32 = 1024
+	SetLimitDetailedBodyBytes(limit)
+
 	var buf bytes.Buffer
-	for i := 0; i < limitDetailedBodyBytes<<2; i++ {
+	for i := 0; i < int(limitDetailedBodyBytes.Load())<<2; i++ {
 		buf.WriteByte('a')
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "http://localhost", &buf)
 	h := DetailedLogHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		io.Copy(io.Discard, r.Body)
+		_, _ = io.Copy(io.Discard, r.Body)
 	}))
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
 
 	// extra 200 for the length of POST request headers
-	assert.True(t, len(lbuf.Content()) < limitDetailedBodyBytes+200)
+	assert.True(t, len(lbuf.Content()) < int(limit)+200)
+}
+
+func TestDetailedLogHandler_LargeBody_NoLimit(t *testing.T) {
+	lbuf := logtest.NewCollector(t)
+
+	// No limit
+	SetLimitDetailedBodyBytes(0)
+	const bodyContentLength = 2048
+	var buf bytes.Buffer
+	for i := 0; i < bodyContentLength; i++ {
+		buf.WriteByte('a')
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost", &buf)
+	h := DetailedLogHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+	}))
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	// No limit, log length is greater than the passed-in body length.
+	assert.True(t, len(lbuf.Content()) > bodyContentLength)
 }
 
 func TestDetailedLogHandler_Hijack(t *testing.T) {


### PR DESCRIPTION
Change the limit to a variable, support external settings, and do not limit by default to prevent break change.